### PR TITLE
bug: branch graph main-lane horizontal spacing looks detached when >=5 lanes (#6)

### DIFF
--- a/src/components/worktree/graph/LaneGraph.tsx
+++ b/src/components/worktree/graph/LaneGraph.tsx
@@ -46,7 +46,7 @@ export const LaneGraph = memo(function LaneGraph({
   const [commitDetail, setCommitDetail] = useState<CommitDetail | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
-  const { lanes, rows, connections, laneW, svgHeight } = layout;
+  const { lanes, rows, connections, laneW, svgHeight, svgWidth } = layout;
 
   // Build SHA → PrInfo map for placing PR badges at correct commit
   const prBySha = useMemo(() => {
@@ -56,9 +56,6 @@ export const LaneGraph = memo(function LaneGraph({
     }
     return map;
   }, [prMap]);
-
-  // SVG width = only the graph portion (lanes + padding)
-  const graphW = LEFT_PAD + lanes.length * laneW + 12;
 
   // Find which lane is selected
   const selectedLaneIdx = lanes.find((l) => l.branch === selectedBranch)?.laneIndex ?? -1;
@@ -161,8 +158,8 @@ export const LaneGraph = memo(function LaneGraph({
       style={{ minHeight: svgHeight }}
     >
       {/* Left: SVG graph (lanes, dots, curves) — fixed width */}
-      <div className="shrink-0" style={{ width: graphW }}>
-        <svg width={graphW} height={svgHeight} role="img" aria-label="Branch lane graph">
+      <div className="shrink-0" style={{ width: svgWidth }}>
+        <svg width={svgWidth} height={svgHeight} role="img" aria-label="Branch lane graph">
           <title>Branch lane graph</title>
           <defs>
             <filter id="lane-glow">
@@ -664,7 +661,7 @@ export const LaneGraph = memo(function LaneGraph({
         <div
           className="absolute z-10 rounded-lg border border-white/10 bg-zinc-900/95 shadow-xl backdrop-blur-sm"
           style={{
-            left: graphW + 8,
+            left: svgWidth + 8,
             top: expandedRow.y + ROW_H / 2 + 4,
             right: 16,
             minWidth: 280,

--- a/src/components/worktree/graph/__tests__/lane-spacing.test.ts
+++ b/src/components/worktree/graph/__tests__/lane-spacing.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import type { BranchListResponse } from "@/lib/api";
+import { computeLaneW, computeLayout, LEFT_PAD } from "../layout";
+import type { BranchNode, GraphData } from "../types";
+
+const FIVE_BRANCHES = ["main", "feat-a", "feat-b", "review-63", "review-64"] as const;
+
+function make5LaneBranchInfo(): BranchListResponse {
+  return {
+    default_branch: "main",
+    current_branch: "main",
+    branches: [...FIVE_BRANCHES],
+    parents: {
+      "feat-a": "main",
+      "feat-b": "main",
+      "review-63": "main",
+      "review-64": "main",
+    },
+    ahead_behind: {},
+    remote_tracking: {},
+    remote_only_branches: [],
+    last_fetch: null,
+    last_commit_times: {},
+  };
+}
+
+function make5LaneGraphData(): GraphData {
+  return {
+    commits: [
+      {
+        sha: "abc1234",
+        parents: [],
+        refs: ["HEAD -> main"],
+        subject: "initial commit",
+        authored_date: 0,
+      },
+    ],
+  };
+}
+
+function make5LaneNodes(): BranchNode[] {
+  return FIVE_BRANCHES.map((name, i) => ({
+    name,
+    parent: name === "main" ? null : "main",
+    isWorktree: i > 0,
+    isMain: name === "main",
+    isCurrent: name === "main",
+    isDirty: false,
+    hasAgent: false,
+    agentTarget: null,
+    agentStatus: null,
+    diffSummary: null,
+    worktree: null,
+    ahead: i > 0 ? 1 : 0,
+    behind: 0,
+    remote: null,
+    isRemoteOnly: false,
+    lastCommitTime: null,
+  }));
+}
+
+describe("lane graph spacing — 5 lanes", () => {
+  it("computes correct laneW for 5 lanes", () => {
+    expect(computeLaneW(5)).toBe(60);
+  });
+
+  it("assigns exactly 5 lanes", () => {
+    const layout = computeLayout(make5LaneGraphData(), make5LaneBranchInfo(), make5LaneNodes());
+    expect(layout.lanes.length).toBe(5);
+    expect(layout.laneW).toBe(computeLaneW(5));
+  });
+
+  it("lane-0 x-coordinate matches formula: LEFT_PAD + laneW/2", () => {
+    const layout = computeLayout(make5LaneGraphData(), make5LaneBranchInfo(), make5LaneNodes());
+    const { laneW } = layout;
+    // The formula used by LaneGraph: laneX(i) = LEFT_PAD + i*laneW + laneW/2
+    const laneX = (i: number) => LEFT_PAD + i * laneW + laneW / 2;
+    expect(laneX(0)).toBe(LEFT_PAD + laneW / 2);
+  });
+
+  it("inter-lane spacing is uniform (all gaps equal laneW)", () => {
+    const layout = computeLayout(make5LaneGraphData(), make5LaneBranchInfo(), make5LaneNodes());
+    const { laneW } = layout;
+    const laneX = (i: number) => LEFT_PAD + i * laneW + laneW / 2;
+    for (let i = 1; i < 5; i++) {
+      expect(laneX(i) - laneX(i - 1)).toBe(laneW);
+    }
+  });
+
+  it("svgWidth has symmetric LEFT_PAD margins on both sides (fix for main-lane detach)", () => {
+    const layout = computeLayout(make5LaneGraphData(), make5LaneBranchInfo(), make5LaneNodes());
+    const { laneW, svgWidth, lanes } = layout;
+    const laneX = (i: number) => LEFT_PAD + i * laneW + laneW / 2;
+    const lastIdx = lanes.length - 1;
+
+    // Left margin: distance from SVG left edge to the left edge of lane-0 background
+    const leftMargin = laneX(0) - laneW / 2;
+    // Right margin: distance from right edge of last lane's background to SVG right edge
+    const rightMargin = svgWidth - (laneX(lastIdx) + laneW / 2);
+
+    expect(leftMargin).toBe(LEFT_PAD);
+    // Symmetric: right margin must equal left margin so lane 0 is not visually detached
+    expect(rightMargin).toBe(LEFT_PAD);
+    expect(svgWidth).toBe(2 * LEFT_PAD + lanes.length * laneW);
+  });
+});

--- a/src/components/worktree/graph/layout.ts
+++ b/src/components/worktree/graph/layout.ts
@@ -434,7 +434,10 @@ export function computeLayout(
   );
 
   const laneW = computeLaneW(totalLanes);
-  const svgWidth = Math.max(LEFT_PAD + totalLanes * laneW + 500, 600);
+  // Symmetric padding: equal LEFT_PAD on both sides so lane 0's left margin
+  // matches lane N-1's right margin — prevents lane 0 from looking detached.
+  // The old formula included +500 for a label area that is now rendered in HTML.
+  const svgWidth = 2 * LEFT_PAD + totalLanes * laneW;
   const svgHeight = finalY + 40;
 
   return { lanes, rows, connections, laneW, svgWidth, svgHeight };


### PR DESCRIPTION
## Summary

- **Root cause**: `svgWidth` in `layout.ts` used `Math.max(LEFT_PAD + N*laneW + 500, 600)` — the `+500` was for a label column that was later moved to HTML. `LaneGraph.tsx` then computed a local `graphW = LEFT_PAD + N*laneW + 12` with an asymmetric right margin (12px) vs `LEFT_PAD` (20px) on the left. At 5 lanes (laneW=60) this asymmetry became visually prominent: lane 0's SVG background had 20px of blank space before it while lane N-1 had only 12px after, making `main` appear to float leftward away from the other headers.
- **Fix**: `svgWidth = 2 * LEFT_PAD + totalLanes * laneW` (symmetric equal margins). `LaneGraph.tsx` now uses `layout.svgWidth` directly instead of recomputing locally — single source of truth.
- **Test**: Added `graph/__tests__/lane-spacing.test.ts` asserting lane-0 x = `LEFT_PAD + laneW/2`, uniform inter-lane spacing, and `leftMargin === rightMargin === LEFT_PAD` for 5 lanes.

## Test plan

- [x] `pnpm lint` — no errors
- [x] `pnpm build` — builds successfully
- [x] `pnpm test` — 134 tests pass (16 test files), including 5 new lane-spacing tests
- [x] New test `svgWidth has symmetric LEFT_PAD margins on both sides` would fail on the old code and passes with this fix

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)