### PR TITLE
docs: bootstrap CHANGELOG.md with Fixed entries for #1 and #6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to `tmai-react` are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+once tagged releases begin. UI-facing changes that depend on `tmai-api-spec` updates
+will note the minimum spec version required.
+
+## [Unreleased]
+
+### Added
+
+- _nothing yet_
+
+### Changed
+
+- _nothing yet_
+
+### Fixed
+
+- Git panel no longer stays stuck on "Loading branches..." when 8+ branches
+  are present. `listBranches` now fires first in `fetchData` so it claims an
+  HTTP connection slot before slower supplementary requests (`gitGraph`,
+  `listPrs`, `listIssues`) that share the pool with concurrent fetches from
+  other components. ([#1](https://github.com/trust-delta/tmai-react/issues/1),
+  [#7](https://github.com/trust-delta/tmai-react/pull/7))
+- Branch-graph `main` lane no longer appears horizontally detached at >=5
+  lanes. `layout.svgWidth` now uses symmetric `LEFT_PAD` margins
+  (`2 * LEFT_PAD + totalLanes * laneW`) and `LaneGraph` consumes that value
+  directly — the prior local `graphW` computation with asymmetric 20px/12px
+  margins is removed. ([#6](https://github.com/trust-delta/tmai-react/issues/6),
+  [#10](https://github.com/trust-delta/tmai-react/pull/10))
+
+[Unreleased]: https://github.com/trust-delta/tmai-react/compare/main...HEAD


### PR DESCRIPTION
## Summary

- Seeds `CHANGELOG.md` following the [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) format so future releases and fixes have a canonical place to land.
- Includes the first two `Fixed` entries for bugs resolved earlier today: the Git panel "Loading branches..." stick (#1 / #7) and the branch-graph main-lane detachment at >=5 lanes (#6 / #10).
- `[Unreleased]` section remains open for subsequent fixes until the first tagged release.

## Test plan

- [x] File renders in GitHub preview (verified via local markdown)
- [x] Links to issues/PRs resolve correctly
- [x] No code changes — CI should pass (biome / tsc / build / vitest unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 8個以上のブランチが存在する場合、Gitパネルが「ブランチを読み込み中...」のままになっていた問題を修正しました。
  * 5個以上のレーンが存在する場合、ブランチグラフの表示がずれていた問題を修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->