### PR TITLE
feat: visualize send_prompt queue in PreviewPanel (badge + popover) (#3)

### DIFF
--- a/src/components/agent/PreviewPanel.tsx
+++ b/src/components/agent/PreviewPanel.tsx
@@ -6,6 +6,7 @@ import { QueuePopover } from "@/components/ui/QueuePopover";
 import { useQueuedPrompts } from "@/hooks/useQueuedPrompts";
 import { api } from "@/lib/api";
 import type { PreviewSettingsResponse, TranscriptRecord } from "@/lib/api-http";
+import type { ActionOrigin } from "@/types";
 import {
   capHistoryLines,
   charColumns,
@@ -64,6 +65,19 @@ function toTmuxKey(e: KeyboardEvent): string | null {
       return "Space";
     default:
       return null;
+  }
+}
+
+// Render an ActionOrigin discriminated union as a compact label, e.g.
+// "Human:webui", "Agent:main:0.0", "System:pr_monitor"
+function originLabel(o: ActionOrigin): string {
+  switch (o.kind) {
+    case "Human":
+      return `Human:${o.interface}`;
+    case "Agent":
+      return `Agent:${o.id}`;
+    case "System":
+      return `System:${o.subsystem}`;
   }
 }
 
@@ -778,7 +792,7 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
                   {item.prompt}
                 </p>
                 <p className="mt-0.5 text-[10px] text-zinc-500">
-                  {item.origin && <span className="mr-2">{item.origin}</span>}
+                  {item.origin && <span className="mr-2">{originLabel(item.origin)}</span>}
                   {new Date(item.queued_at).toLocaleTimeString()}
                 </p>
               </div>

--- a/src/components/agent/PreviewPanel.tsx
+++ b/src/components/agent/PreviewPanel.tsx
@@ -1,6 +1,9 @@
 import { AnsiUp } from "ansi_up";
 import DOMPurify from "dompurify";
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
+import { QueueBadge } from "@/components/ui/QueueBadge";
+import { QueuePopover } from "@/components/ui/QueuePopover";
+import { useQueuedPrompts } from "@/hooks/useQueuedPrompts";
 import { api } from "@/lib/api";
 import type { PreviewSettingsResponse, TranscriptRecord } from "@/lib/api-http";
 import {
@@ -102,6 +105,8 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
   const [cursorPos, setCursorPos] = useState<CursorPos | null>(null);
   const [showCursor, setShowCursor] = useState(true);
   const [focused, setFocused] = useState(true);
+  const [queueOpen, setQueueOpen] = useState(false);
+  const { items: queueItems, cancel: cancelQueueItem } = useQueuedPrompts(agentId);
   const [composing, setComposing] = useState(false);
   // Mirror `composing` into a ref so fetchPreview / poll-tick closures can
   // read the current composition state without being re-created (which
@@ -754,6 +759,32 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
         >
           {showCursor ? "▮ Cursor" : "▯ Cursor"}
         </button>
+        <div className="relative">
+          <QueueBadge
+            count={queueItems.length}
+            onClick={() => setQueueOpen((v) => !v)}
+            icon="✉"
+            title={`${queueItems.length} prompt${queueItems.length !== 1 ? "s" : ""} queued — click to view`}
+          />
+          <QueuePopover
+            items={queueItems}
+            isOpen={queueOpen && queueItems.length > 0}
+            onClose={() => setQueueOpen(false)}
+            onCancel={cancelQueueItem}
+            title="Queued Prompts"
+            renderItem={(item) => (
+              <div>
+                <p className="truncate text-[11px] text-zinc-200" title={item.prompt}>
+                  {item.prompt}
+                </p>
+                <p className="mt-0.5 text-[10px] text-zinc-500">
+                  {item.origin && <span className="mr-2">{item.origin}</span>}
+                  {new Date(item.queued_at).toLocaleTimeString()}
+                </p>
+              </div>
+            )}
+          />
+        </div>
         <div className="flex-1" />
         <span className="text-[10px] text-zinc-600">
           {focused ? "click to select" : "Enter or click ⌨ to input"}

--- a/src/components/agent/__tests__/PreviewPanel-queue.test.tsx
+++ b/src/components/agent/__tests__/PreviewPanel-queue.test.tsx
@@ -32,7 +32,12 @@ const { api } = await import("@/lib/api");
 const { PreviewPanel } = await import("../PreviewPanel");
 
 const QUEUED: QueuedPrompt[] = [
-  { id: "q1", prompt: "run the tests", queued_at: "2026-04-20T10:00:00Z", origin: "orchestrator" },
+  {
+    id: "q1",
+    prompt: "run the tests",
+    queued_at: "2026-04-20T10:00:00Z",
+    origin: { kind: "Agent", id: "main:0.0", is_orchestrator: true },
+  },
 ];
 
 describe("PreviewPanel queue badge", () => {

--- a/src/components/agent/__tests__/PreviewPanel-queue.test.tsx
+++ b/src/components/agent/__tests__/PreviewPanel-queue.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { QueuedPrompt } from "@/lib/api";
+
+// ── jsdom stubs for DOM APIs not implemented in jsdom ──
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+Element.prototype.scrollIntoView = vi.fn();
+
+// ── mock @/lib/api ──
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  const hang = new Promise<never>(() => {});
+  return {
+    ...actual,
+    api: {
+      getPreview: () => hang,
+      getPreviewInput: () => hang,
+      getTranscript: () => hang,
+      getPreviewSettings: () => hang,
+      getPromptQueue: vi.fn(),
+      cancelQueuedPrompt: vi.fn().mockResolvedValue({ status: "cancelled" }),
+    },
+  };
+});
+
+const { api } = await import("@/lib/api");
+const { PreviewPanel } = await import("../PreviewPanel");
+
+const QUEUED: QueuedPrompt[] = [
+  { id: "q1", prompt: "run the tests", queued_at: "2026-04-20T10:00:00Z", origin: "orchestrator" },
+];
+
+describe("PreviewPanel queue badge", () => {
+  it("shows queue badge when prompt-queue returns items", async () => {
+    vi.mocked(api.getPromptQueue).mockResolvedValue(QUEUED);
+    render(<PreviewPanel agentId="test-agent" />);
+    // Badge button carries the count in its title attribute
+    await waitFor(() => {
+      expect(screen.getByTitle(/queued/)).toBeTruthy();
+    });
+  });
+
+  it("badge is absent when queue is empty", async () => {
+    vi.mocked(api.getPromptQueue).mockResolvedValue([]);
+    render(<PreviewPanel agentId="test-agent" />);
+    await waitFor(() => expect(vi.mocked(api.getPromptQueue)).toHaveBeenCalled());
+    expect(screen.queryByTitle(/queued/)).toBeNull();
+  });
+});

--- a/src/components/ui/QueueBadge.tsx
+++ b/src/components/ui/QueueBadge.tsx
@@ -1,0 +1,24 @@
+interface QueueBadgeProps {
+  count: number;
+  onClick: () => void;
+  icon?: string;
+  title?: string;
+}
+
+// Generic badge button for any pending-item queue.
+// Renders nothing when count is 0 — callers need no guard.
+// Reusable for send_prompt (#3) and notification mixing (#9).
+export function QueueBadge({ count, onClick, icon = "✉", title }: QueueBadgeProps) {
+  if (count === 0) return null;
+  return (
+    <button
+      type="button"
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onClick}
+      className="rounded px-1.5 py-0.5 text-[10px] transition-colors bg-amber-500/20 text-amber-400 hover:bg-amber-500/30"
+      title={title ?? `${count} item${count !== 1 ? "s" : ""} queued — click to view`}
+    >
+      {icon} {count}
+    </button>
+  );
+}

--- a/src/components/ui/QueuePopover.tsx
+++ b/src/components/ui/QueuePopover.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useRef } from "react";
+
+interface QueuePopoverProps<T extends { id: string }> {
+  items: T[];
+  renderItem: (item: T) => React.ReactNode;
+  isOpen: boolean;
+  onClose: () => void;
+  onCancel: (id: string) => void;
+  title?: string;
+}
+
+// Generic popover listing pending queue items with per-item cancel.
+// Positions itself above its nearest relative-positioned ancestor.
+// Closes on outside click. Reusable for send_prompt (#3) and #9.
+export function QueuePopover<T extends { id: string }>({
+  items,
+  renderItem,
+  isOpen,
+  onClose,
+  onCancel,
+  title = "Queued items",
+}: QueuePopoverProps<T>) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    function handleMouseDown(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+    document.addEventListener("mousedown", handleMouseDown);
+    return () => document.removeEventListener("mousedown", handleMouseDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen || items.length === 0) return null;
+
+  return (
+    <div
+      ref={ref}
+      className="absolute bottom-full left-0 z-50 mb-1 w-80 rounded-lg border border-white/10 bg-[#1a1a1a] shadow-xl"
+    >
+      <div className="flex items-center justify-between border-b border-white/10 px-3 py-2">
+        <span className="text-[11px] font-medium text-zinc-300">{title}</span>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-[10px] text-zinc-500 hover:text-zinc-300 transition-colors"
+          aria-label="Close"
+        >
+          ✕
+        </button>
+      </div>
+      <ul className="max-h-60 divide-y divide-white/5 overflow-y-auto">
+        {items.map((item) => (
+          <li key={item.id} className="flex items-start gap-2 px-3 py-2">
+            <div className="min-w-0 flex-1">{renderItem(item)}</div>
+            <button
+              type="button"
+              onClick={() => onCancel(item.id)}
+              className="shrink-0 rounded px-1.5 py-0.5 text-[10px] text-red-400 transition-colors hover:bg-red-500/20"
+              aria-label="Cancel queued prompt"
+            >
+              Cancel
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/ui/__tests__/QueueBadge.test.tsx
+++ b/src/components/ui/__tests__/QueueBadge.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { QueueBadge } from "../QueueBadge";
+
+describe("QueueBadge", () => {
+  it("renders nothing when count is 0", () => {
+    const { container } = render(<QueueBadge count={0} onClick={() => {}} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows count when non-zero", () => {
+    render(<QueueBadge count={3} onClick={() => {}} />);
+    const btn = screen.getByRole("button");
+    expect(btn.textContent).toContain("3");
+  });
+
+  it("calls onClick when clicked", () => {
+    const onClick = vi.fn();
+    render(<QueueBadge count={1} onClick={onClick} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("uses custom icon prop", () => {
+    render(<QueueBadge count={2} onClick={() => {}} icon="📬" />);
+    expect(screen.getByRole("button").textContent).toContain("📬");
+  });
+
+  it("applies custom title", () => {
+    render(<QueueBadge count={1} onClick={() => {}} title="my custom title" />);
+    expect(screen.getByRole("button").title).toBe("my custom title");
+  });
+});

--- a/src/components/ui/__tests__/QueuePopover.test.tsx
+++ b/src/components/ui/__tests__/QueuePopover.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { QueuePopover } from "../QueuePopover";
+
+interface Item {
+  id: string;
+  label: string;
+}
+
+const ITEMS: Item[] = [
+  { id: "a", label: "First item" },
+  { id: "b", label: "Second item" },
+];
+
+function renderItem(item: Item) {
+  return <span>{item.label}</span>;
+}
+
+describe("QueuePopover", () => {
+  it("renders nothing when isOpen is false", () => {
+    const { container } = render(
+      <QueuePopover
+        items={ITEMS}
+        renderItem={renderItem}
+        isOpen={false}
+        onClose={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when items list is empty (even if open)", () => {
+    const { container } = render(
+      <QueuePopover
+        items={[]}
+        renderItem={renderItem}
+        isOpen={true}
+        onClose={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders all items when open", () => {
+    render(
+      <QueuePopover
+        items={ITEMS}
+        renderItem={renderItem}
+        isOpen={true}
+        onClose={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    expect(screen.getByText("First item")).toBeTruthy();
+    expect(screen.getByText("Second item")).toBeTruthy();
+  });
+
+  it("calls onCancel with the item id when Cancel is clicked", () => {
+    const onCancel = vi.fn();
+    render(
+      <QueuePopover
+        items={ITEMS}
+        renderItem={renderItem}
+        isOpen={true}
+        onClose={() => {}}
+        onCancel={onCancel}
+      />,
+    );
+    // First Cancel button corresponds to ITEMS[0]
+    const cancelButtons = screen.getAllByRole("button", { name: /cancel queued prompt/i });
+    fireEvent.click(cancelButtons[0]);
+    expect(onCancel).toHaveBeenCalledWith("a");
+  });
+
+  it("calls onClose when the close button is clicked", () => {
+    const onClose = vi.fn();
+    render(
+      <QueuePopover
+        items={ITEMS}
+        renderItem={renderItem}
+        isOpen={true}
+        onClose={onClose}
+        onCancel={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Close"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("displays custom title", () => {
+    render(
+      <QueuePopover
+        items={ITEMS}
+        renderItem={renderItem}
+        isOpen={true}
+        onClose={() => {}}
+        onCancel={() => {}}
+        title="Pending Prompts"
+      />,
+    );
+    expect(screen.getByText("Pending Prompts")).toBeTruthy();
+  });
+});

--- a/src/hooks/__tests__/useQueuedPrompts.test.ts
+++ b/src/hooks/__tests__/useQueuedPrompts.test.ts
@@ -53,8 +53,32 @@ describe("useQueuedPrompts", () => {
     expect(result.current.items[0].id).toBe("2");
   });
 
-  it("re-syncs via refresh after a failed cancel", async () => {
-    vi.mocked(api.cancelQueuedPrompt).mockRejectedValue(new Error("already delivered"));
+  it("does NOT re-sync when cancel returns 'cancelled'", async () => {
+    vi.mocked(api.cancelQueuedPrompt).mockResolvedValue({ status: "cancelled" });
+    const { result } = renderHook(() => useQueuedPrompts("agent-1"));
+    await waitFor(() => expect(result.current.items).toHaveLength(2));
+
+    const callsBefore = vi.mocked(api.getPromptQueue).mock.calls.length;
+    await act(async () => {
+      await result.current.cancel("1");
+    });
+    expect(vi.mocked(api.getPromptQueue).mock.calls.length).toBe(callsBefore);
+  });
+
+  it("does NOT re-sync when cancel returns 'already_drained' (idempotent success)", async () => {
+    vi.mocked(api.cancelQueuedPrompt).mockResolvedValue({ status: "already_drained" });
+    const { result } = renderHook(() => useQueuedPrompts("agent-1"));
+    await waitFor(() => expect(result.current.items).toHaveLength(2));
+
+    const callsBefore = vi.mocked(api.getPromptQueue).mock.calls.length;
+    await act(async () => {
+      await result.current.cancel("1");
+    });
+    expect(vi.mocked(api.getPromptQueue).mock.calls.length).toBe(callsBefore);
+  });
+
+  it("re-syncs via refresh after an actual failure (network / 404)", async () => {
+    vi.mocked(api.cancelQueuedPrompt).mockRejectedValue(new Error("404 Not Found"));
     const { result } = renderHook(() => useQueuedPrompts("agent-1"));
     await waitFor(() => expect(result.current.items).toHaveLength(2));
 
@@ -70,7 +94,6 @@ describe("useQueuedPrompts", () => {
   it("registers a 3 s polling interval on mount", () => {
     const spy = vi.spyOn(global, "setInterval");
     const { unmount } = renderHook(() => useQueuedPrompts("agent-1"));
-    // The hook should register exactly one interval with a 3000 ms delay
     const intervals = spy.mock.calls.filter(([, ms]) => ms === 3000);
     expect(intervals).toHaveLength(1);
     unmount();

--- a/src/hooks/__tests__/useQueuedPrompts.test.ts
+++ b/src/hooks/__tests__/useQueuedPrompts.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// vi.mock is hoisted before static imports
+vi.mock("@/lib/api", () => ({
+  api: {
+    getPromptQueue: vi.fn(),
+    cancelQueuedPrompt: vi.fn(),
+  },
+}));
+
+import type { QueuedPrompt } from "@/lib/api";
+import { api } from "@/lib/api";
+import { useQueuedPrompts } from "../useQueuedPrompts";
+
+const ITEMS: QueuedPrompt[] = [
+  { id: "1", prompt: "hello world", queued_at: "2026-04-20T10:00:00Z" },
+  { id: "2", prompt: "do something", queued_at: "2026-04-20T10:00:01Z" },
+];
+
+describe("useQueuedPrompts", () => {
+  beforeEach(() => {
+    vi.mocked(api.getPromptQueue).mockResolvedValue(ITEMS);
+    vi.mocked(api.cancelQueuedPrompt).mockResolvedValue({ status: "cancelled" });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("populates items after initial fetch", async () => {
+    const { result } = renderHook(() => useQueuedPrompts("agent-1"));
+    await waitFor(() => expect(result.current.items).toHaveLength(2));
+    expect(result.current.items[0].id).toBe("1");
+  });
+
+  it("returns empty array while API is unreachable", async () => {
+    vi.mocked(api.getPromptQueue).mockRejectedValue(new Error("network error"));
+    const { result } = renderHook(() => useQueuedPrompts("agent-1"));
+    await waitFor(() => expect(vi.mocked(api.getPromptQueue)).toHaveBeenCalled());
+    expect(result.current.items).toHaveLength(0);
+  });
+
+  it("removes item optimistically on cancel", async () => {
+    const { result } = renderHook(() => useQueuedPrompts("agent-1"));
+    await waitFor(() => expect(result.current.items).toHaveLength(2));
+
+    act(() => {
+      result.current.cancel("1");
+    });
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0].id).toBe("2");
+  });
+
+  it("re-syncs via refresh after a failed cancel", async () => {
+    vi.mocked(api.cancelQueuedPrompt).mockRejectedValue(new Error("already delivered"));
+    const { result } = renderHook(() => useQueuedPrompts("agent-1"));
+    await waitFor(() => expect(result.current.items).toHaveLength(2));
+
+    const callsBefore = vi.mocked(api.getPromptQueue).mock.calls.length;
+    await act(async () => {
+      await result.current.cancel("1");
+    });
+    await waitFor(() =>
+      expect(vi.mocked(api.getPromptQueue).mock.calls.length).toBeGreaterThan(callsBefore),
+    );
+  });
+
+  it("registers a 3 s polling interval on mount", () => {
+    const spy = vi.spyOn(global, "setInterval");
+    const { unmount } = renderHook(() => useQueuedPrompts("agent-1"));
+    // The hook should register exactly one interval with a 3000 ms delay
+    const intervals = spy.mock.calls.filter(([, ms]) => ms === 3000);
+    expect(intervals).toHaveLength(1);
+    unmount();
+    spy.mockRestore();
+  });
+});

--- a/src/hooks/useQueuedPrompts.ts
+++ b/src/hooks/useQueuedPrompts.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useState } from "react";
+import type { QueuedPrompt } from "@/lib/api";
+import { api } from "@/lib/api";
+
+// Polls the pending send_prompt queue for an agent every 3 s.
+// Optimistically removes cancelled items; re-syncs on cancel failure
+// (race: agent became idle and flushed the queue simultaneously).
+export function useQueuedPrompts(agentId: string) {
+  const [items, setItems] = useState<QueuedPrompt[]>([]);
+
+  const refresh = useCallback(async () => {
+    try {
+      const queue = await api.getPromptQueue(agentId);
+      setItems(queue);
+    } catch {
+      // Endpoint not yet reachable (backend may be starting up); treat as empty.
+    }
+  }, [agentId]);
+
+  const cancel = useCallback(
+    async (promptId: string) => {
+      setItems((prev) => prev.filter((item) => item.id !== promptId));
+      try {
+        await api.cancelQueuedPrompt(agentId, promptId);
+      } catch {
+        // "Already delivered" is a benign race; re-sync to get accurate state.
+        refresh();
+      }
+    },
+    [agentId, refresh],
+  );
+
+  useEffect(() => {
+    refresh();
+    const interval = setInterval(refresh, 3000);
+    return () => clearInterval(interval);
+  }, [refresh]);
+
+  return { items, cancel, refresh };
+}

--- a/src/hooks/useQueuedPrompts.ts
+++ b/src/hooks/useQueuedPrompts.ts
@@ -22,8 +22,10 @@ export function useQueuedPrompts(agentId: string) {
       setItems((prev) => prev.filter((item) => item.id !== promptId));
       try {
         await api.cancelQueuedPrompt(agentId, promptId);
+        // Both "cancelled" and "already_drained" are success statuses —
+        // the optimistic remove already matches reality; no re-sync needed.
       } catch {
-        // "Already delivered" is a benign race; re-sync to get accurate state.
+        // Actual failure (network, 404 on unknown agent, etc.) — re-sync.
         refresh();
       }
     },

--- a/src/lib/api-http.ts
+++ b/src/lib/api-http.ts
@@ -146,6 +146,15 @@ export interface AgentSnapshot {
   is_orchestrator?: boolean;
 }
 
+// ── Prompt Queue ──
+
+export interface QueuedPrompt {
+  id: string;
+  prompt: string;
+  queued_at: string; // ISO 8601
+  origin?: string;
+}
+
 // ── Project grouping ──
 
 // A worktree (or main) within a project, containing agents
@@ -832,6 +841,13 @@ export const api = {
     ),
   getTranscript: (target: string) =>
     apiFetch<{ records: TranscriptRecord[] }>(`/agents/${encodeURIComponent(target)}/transcript`),
+  getPromptQueue: (agentId: string) =>
+    apiFetch<QueuedPrompt[]>(`/agents/${encodeURIComponent(agentId)}/prompt-queue`),
+  cancelQueuedPrompt: (agentId: string, promptId: string) =>
+    apiFetch<{ status: string }>(
+      `/agents/${encodeURIComponent(agentId)}/prompt-queue/${encodeURIComponent(promptId)}`,
+      { method: "DELETE" },
+    ),
 
   // Spawn
   spawnPty: (req: SpawnRequest) =>

--- a/src/lib/api-http.ts
+++ b/src/lib/api-http.ts
@@ -148,11 +148,13 @@ export interface AgentSnapshot {
 
 // ── Prompt Queue ──
 
+import type { ActionOrigin } from "@/types";
+
 export interface QueuedPrompt {
   id: string;
   prompt: string;
-  queued_at: string; // ISO 8601
-  origin?: string;
+  queued_at: string; // RFC 3339
+  origin?: ActionOrigin;
 }
 
 // ── Project grouping ──
@@ -844,7 +846,7 @@ export const api = {
   getPromptQueue: (agentId: string) =>
     apiFetch<QueuedPrompt[]>(`/agents/${encodeURIComponent(agentId)}/prompt-queue`),
   cancelQueuedPrompt: (agentId: string, promptId: string) =>
-    apiFetch<{ status: string }>(
+    apiFetch<{ status: "cancelled" | "already_drained" }>(
       `/agents/${encodeURIComponent(agentId)}/prompt-queue/${encodeURIComponent(promptId)}`,
       { method: "DELETE" },
     ),

--- a/src/lib/api-tauri.ts
+++ b/src/lib/api-tauri.ts
@@ -108,6 +108,9 @@ export const api = {
   getPreview: (target: string) => httpApi.getPreview(target),
   getPreviewInput: (target: string, lines = 8) => httpApi.getPreviewInput(target, lines),
   getTranscript: (target: string) => httpApi.getTranscript(target),
+  getPromptQueue: (agentId: string) => httpApi.getPromptQueue(agentId),
+  cancelQueuedPrompt: (agentId: string, promptId: string) =>
+    httpApi.cancelQueuedPrompt(agentId, promptId),
 
   // Spawn
   spawnPty: (req: SpawnRequest) => httpApi.spawnPty(req),


### PR DESCRIPTION
## Summary

- **Generic primitives** `QueueBadge` + `QueuePopover` in `src/components/ui/` — reusable for future #9 (notification mixing) without structural changes
- **`useQueuedPrompts(agentId)`** hook in `src/hooks/` polls `GET /api/agents/:id/prompt-queue` every 3 s with optimistic cancel and safe re-sync on failure (handles the race where the agent flushed the queue before DELETE arrives)
- **API layer** — `getPromptQueue` / `cancelQueuedPrompt` added to `api-http.ts` and proxied in `api-tauri.ts`
- **PreviewPanel footer** gets an amber `✉ N` badge (hidden at 0) + popover listing each prompt with timestamp, origin, and per-item Cancel button

## Reusability design (for #9)

`QueueBadge<T>` and `QueuePopover<T extends { id }>`are parameterised generics. To add a notification queue in #9, the consumer only needs to:
1. Write a new polling hook (same shape as `useQueuedPrompts`)
2. Pass its items + a `renderItem` callback to the existing primitives — no forking

## Test plan

- [x] `pnpm test` — 155 tests pass (21 test files), including:
  - `useQueuedPrompts` — initial fetch, optimistic cancel, failed-cancel re-sync, 3 s interval registration
  - `QueueBadge` — hidden at 0, count display, onClick, custom icon/title
  - `QueuePopover` — closed/open/empty states, onCancel callback, onClose callback, custom title
  - `PreviewPanel-queue` integration — badge visible when queue returns items, absent when empty
- [x] `pnpm lint` — no errors (biome)
- [x] `pnpm build` — TypeScript + Vite build clean

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * プレビューパネルにプロンプトキューの表示機能を追加。待機中のプロンプト数をバッジで表示し、クリックするとキュー内容の詳細を確認できます。キュー内のプロンプトはキャンセル可能です。

* **テスト**
  * キューUI機能と関連コンポーネントの包括的なテストスイートを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->