### PR TITLE
feat(api-client): include caller cwd in X-Tmai-Origin header to prevent WebUI notification suppression under fail-closed notify scope (#15)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useResponsiveLayout } from "@/hooks/useResponsiveLayout";
 import { useSplitPane } from "@/hooks/useSplitPane";
 import { useWorktrees } from "@/hooks/useWorktrees";
-import { api, isAiAgent, setCallerCwd, type Selection, statusName } from "@/lib/api";
+import { api, isAiAgent, type Selection, setCallerCwd, statusName } from "@/lib/api";
 import { useSSE } from "@/lib/sse-provider";
 
 export function App() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useResponsiveLayout } from "@/hooks/useResponsiveLayout";
 import { useSplitPane } from "@/hooks/useSplitPane";
 import { useWorktrees } from "@/hooks/useWorktrees";
-import { api, isAiAgent, type Selection, statusName } from "@/lib/api";
+import { api, isAiAgent, setCallerCwd, type Selection, statusName } from "@/lib/api";
 import { useSSE } from "@/lib/sse-provider";
 
 export function App() {
@@ -99,6 +99,11 @@ export function App() {
   useEffect(() => {
     refreshProjects();
   }, [refreshProjects]);
+
+  // Sync selected project into the API client so X-Tmai-Origin carries cwd.
+  useEffect(() => {
+    setCallerCwd(currentProject);
+  }, [currentProject]);
 
   // Split agents into AI agents and plain terminals
   const aiAgents = useMemo(() => agents.filter((a) => isAiAgent(a.agent_type)), [agents]);

--- a/src/lib/__tests__/api-http-origin.test.ts
+++ b/src/lib/__tests__/api-http-origin.test.ts
@@ -18,7 +18,8 @@ function okResponse(): Response {
 }
 
 function lastOriginHeader(): Record<string, unknown> | null {
-  const call = mockFetch.mock.calls.at(-1);
+  const calls = mockFetch.mock.calls;
+  const call = calls.length > 0 ? calls[calls.length - 1] : undefined;
   if (!call) return null;
   const opts = call[1] as RequestInit;
   const headers = opts.headers as Record<string, string>;

--- a/src/lib/__tests__/api-http-origin.test.ts
+++ b/src/lib/__tests__/api-http-origin.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Stub window.location before module import so getConfig() resolves correctly.
+Object.defineProperty(window, "location", {
+  value: { origin: "http://localhost", search: "?token=tok" },
+  writable: true,
+});
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// Import after stubs are in place.
+import { api, setCallerCwd } from "../api-http";
+
+function okResponse(): Response {
+  return new Response(JSON.stringify({}), { status: 200 });
+}
+
+function lastOriginHeader(): Record<string, unknown> | null {
+  const call = mockFetch.mock.calls.at(-1);
+  if (!call) return null;
+  const opts = call[1] as RequestInit;
+  const headers = opts.headers as Record<string, string>;
+  const raw = headers["X-Tmai-Origin"];
+  return raw ? (JSON.parse(raw) as Record<string, unknown>) : null;
+}
+
+describe("X-Tmai-Origin header — state-changing requests", () => {
+  beforeEach(() => {
+    mockFetch.mockResolvedValue(okResponse());
+    setCallerCwd(null);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("includes cwd when a project is selected on POST", async () => {
+    setCallerCwd("/home/user/project-a");
+    await api.approve("agent-1");
+    const h = lastOriginHeader();
+    expect(h).toEqual({ kind: "Human", interface: "webui", cwd: "/home/user/project-a" });
+  });
+
+  it("omits cwd from header when no project is selected", async () => {
+    setCallerCwd(null);
+    await api.approve("agent-1");
+    const h = lastOriginHeader();
+    expect(h).toEqual({ kind: "Human", interface: "webui" });
+    expect(h?.cwd).toBeUndefined();
+  });
+
+  it("reflects project switch between calls", async () => {
+    setCallerCwd("/project-1");
+    await api.approve("agent-1");
+    expect(lastOriginHeader()?.cwd).toBe("/project-1");
+
+    vi.clearAllMocks();
+    mockFetch.mockResolvedValue(okResponse());
+
+    setCallerCwd("/project-2");
+    await api.approve("agent-1");
+    expect(lastOriginHeader()?.cwd).toBe("/project-2");
+  });
+
+  it("clears cwd after setCallerCwd(null)", async () => {
+    setCallerCwd("/project-x");
+    setCallerCwd(null);
+    await api.approve("agent-1");
+    expect(lastOriginHeader()?.cwd).toBeUndefined();
+  });
+});
+
+describe("X-Tmai-Origin header — read-only requests", () => {
+  beforeEach(() => {
+    mockFetch.mockResolvedValue(new Response(JSON.stringify([]), { status: 200 }));
+    setCallerCwd("/some-project");
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does NOT inject X-Tmai-Origin on GET requests", async () => {
+    await api.listAgents();
+    expect(lastOriginHeader()).toBeNull();
+  });
+});

--- a/src/lib/api-http.ts
+++ b/src/lib/api-http.ts
@@ -13,14 +13,36 @@ function getConfig(): { baseUrl: string; token: string } {
 
 const config = getConfig();
 
+// Updated by setCallerCwd() in App.tsx whenever the selected project changes.
+// Injected into X-Tmai-Origin on state-changing requests so the orchestrator
+// can resolve the source project for fail-closed notification scoping.
+let callerCwd: string | null = null;
+
+export function setCallerCwd(cwd: string | null): void {
+  callerCwd = cwd;
+}
+
+const STATE_CHANGING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
 // Authenticated fetch helper
 async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
   const url = `${config.baseUrl}/api${path}`;
+  const method = (options.method ?? "GET").toUpperCase();
+  const originHeaders: Record<string, string> = {};
+  if (STATE_CHANGING_METHODS.has(method)) {
+    const origin: { kind: "Human"; interface: string; cwd?: string } = {
+      kind: "Human",
+      interface: "webui",
+      ...(callerCwd !== null ? { cwd: callerCwd } : {}),
+    };
+    originHeaders["X-Tmai-Origin"] = JSON.stringify(origin);
+  }
   const res = await fetch(url, {
     ...options,
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${config.token}`,
+      ...originHeaders,
       ...options.headers,
     },
   });

--- a/src/lib/api-http.ts
+++ b/src/lib/api-http.ts
@@ -42,8 +42,10 @@ async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> 
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${config.token}`,
-      ...originHeaders,
       ...options.headers,
+      // X-Tmai-Origin is authoritative for fail-closed scope; spread LAST
+      // so callers cannot override it via options.headers.
+      ...originHeaders,
     },
   });
   if (!res.ok) {

--- a/src/types/generated/ActionOrigin.ts
+++ b/src/types/generated/ActionOrigin.ts
@@ -13,6 +13,11 @@ export type ActionOrigin =
        * Which interface: "webui", "tui", "mobile", "cli", etc.
        */
       interface: string;
+      /**
+       * Caller working directory — the currently-selected project root.
+       * Omitted when no project is selected (server accepts missing field via serde default).
+       */
+      cwd?: string;
     }
   | {
       kind: "Agent";


### PR DESCRIPTION
## Summary

- `apiFetch()` に `X-Tmai-Origin` ヘッダー注入ロジックを追加。POST/PUT/PATCH/DELETE のstate-changing リクエストのみ対象
- `setCallerCwd(cwd)` をエクスポートし、`App.tsx` が `currentProject` 変化時に同期
- プロジェクト未選択時は `cwd` フィールドを省略（サーバーは `serde default` で受け入れる）
- `ActionOrigin.Human` 型に `cwd?: string` フィールドを追加（tmai-api-spec lockstep）

## Changed files

| File | Change |
|---|---|
| `src/lib/api-http.ts` | `setCallerCwd()` エクスポート + `apiFetch()` ヘッダー注入 |
| `src/App.tsx` | `useEffect` で `setCallerCwd(currentProject)` を呼び出し |
| `src/types/generated/ActionOrigin.ts` | `Human` バリアントに `cwd?: string` 追加 |
| `src/lib/__tests__/api-http-origin.test.ts` | 5テスト（POST+cwd, POST無cwd, プロジェクト切替, null解除, GETは無ヘッダー） |

## Test plan

- [x] `npx vitest run src/lib/__tests__/api-http-origin.test.ts` → 5/5 pass
- [x] `npx tsc --noEmit` → エラーなし
- [ ] Manual: tmai-core#92 適用後にWebUI操作でオーケストレーター通知がクロスプロジェクトリークなく到達することを確認

## Related

- Closes #15
- trust-delta/tmai-core#89 (fail-closed notify scope)
- trust-delta/tmai-core#92 (implementing PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)