### PR TITLE
fix: PTY mode conversation panel behavior differs from tmux mode (selection, scrolling) (#4)

### DIFF
--- a/src/components/agent/PreviewPanel.tsx
+++ b/src/components/agent/PreviewPanel.tsx
@@ -152,6 +152,10 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  // Tracks whether the current mousedown originated in input mode and triggered
+  // a preemptive enterSelectMode(). On mouseup we check this to cancel the
+  // mode switch when no text was actually selected (plain click, no drag).
+  const pendingSelectRef = useRef(false);
 
   // Measure character columns that fit in the preview container
   const [cols, setCols] = useState(0);
@@ -581,17 +585,18 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
   }, [historyHtml]);
 
   useEffect(() => {
-    if (liveRef.current) {
-      const sel = window.getSelection();
-      const hasSelection = sel && sel.toString().length > 0;
-      if (!hasSelection && liveHtml !== lastLiveHtmlRef.current) {
-        lastLiveHtmlRef.current = liveHtml;
-        liveRef.current.innerHTML = DOMPurify.sanitize(liveHtml, {
-          ADD_ATTR: ["data-tmai-cursor"],
-        });
-      }
+    const sel = window.getSelection();
+    const hasSelection = !!(sel && sel.toString().length > 0);
+
+    if (liveRef.current && !hasSelection && liveHtml !== lastLiveHtmlRef.current) {
+      lastLiveHtmlRef.current = liveHtml;
+      liveRef.current.innerHTML = DOMPurify.sanitize(liveHtml, {
+        ADD_ATTR: ["data-tmai-cursor"],
+      });
     }
-    if (autoScroll) {
+    // Guard auto-scroll against active text selection: jumping the viewport
+    // while the user is dragging to select text destroys the selection anchor.
+    if (autoScroll && !hasSelection) {
       bottomRef.current?.scrollIntoView({ behavior: "instant" });
     }
 
@@ -613,8 +618,9 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
       setCursorStyle(null);
       return;
     }
-
-    const lineH = 13 * 1.35;
+    // Measure the actual rendered line height rather than hardcoding font
+    // metrics; the span carries the same font stack as the preview content.
+    const lineH = charSpan.getBoundingClientRect().height || 13 * 1.35;
     setCursorStyle({
       left: `${marker.offsetLeft}px`,
       top: `${marker.offsetTop}px`,
@@ -637,16 +643,28 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
         ref={scrollContainerRef}
         onScroll={handleScroll}
         onMouseDown={() => {
-          if (focused) enterSelectMode();
+          if (focused) {
+            // Switch to select mode so keystrokes aren't sent while the user
+            // drags. On mouseup we cancel this if no text was actually selected.
+            enterSelectMode();
+            pendingSelectRef.current = true;
+          }
         }}
         onMouseUp={() => {
-          // If no text was selected (just a click), return to input mode.
-          // Also handles re-focus when clicking back from the right panel.
+          const sel = window.getSelection();
+          const hasSelection = !!(sel && sel.toString().length > 0);
+          if (pendingSelectRef.current) {
+            // mousedown came from input mode — only stay in select mode if the
+            // user actually dragged out a selection; a plain click returns to
+            // input mode so the user isn't unexpectedly locked out of typing.
+            pendingSelectRef.current = false;
+            if (!hasSelection) enterInputMode();
+            return;
+          }
+          // In select mode (via button) or re-focusing from another panel:
+          // a click with no selection returns to input mode.
           if (!focused || !hasDomFocus) {
-            const sel = window.getSelection();
-            if (!sel || sel.toString().length === 0) {
-              enterInputMode();
-            }
+            if (!hasSelection) enterInputMode();
           }
         }}
         className={`flex-1 overflow-y-auto p-3 text-[13px] leading-[1.35] ${

--- a/src/components/agent/__tests__/PreviewPanel-interaction.test.tsx
+++ b/src/components/agent/__tests__/PreviewPanel-interaction.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+// Tests for PTY mode conversation panel selection / scroll UX (#4).
+import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+Element.prototype.scrollIntoView = vi.fn();
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  const hang = new Promise<never>(() => {});
+  return {
+    ...actual,
+    api: {
+      getPreview: () => hang,
+      getPreviewInput: () => hang,
+      getTranscript: () => hang,
+      getPreviewSettings: () => hang,
+      getPromptQueue: vi.fn().mockResolvedValue([]),
+      cancelQueuedPrompt: vi.fn().mockResolvedValue({ status: "cancelled" }),
+    },
+  };
+});
+
+const { PreviewPanel } = await import("../PreviewPanel");
+
+// Helper: mock window.getSelection to return a specific string
+function mockSelection(text: string) {
+  const sel = {
+    toString: () => text,
+    rangeCount: text ? 1 : 0,
+  } as unknown as Selection;
+  vi.spyOn(window, "getSelection").mockReturnValue(sel);
+}
+
+describe("PreviewPanel input/select mode", () => {
+  beforeEach(() => {
+    mockSelection(""); // no selection by default
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("starts in input mode", async () => {
+    render(<PreviewPanel agentId="agent-1" />);
+    await waitFor(() => {
+      expect(screen.getByTitle(/Input mode/)).toBeTruthy();
+    });
+  });
+
+  it("plain click in input mode stays in input mode", async () => {
+    render(<PreviewPanel agentId="agent-2" />);
+    // Wait for initial render
+    await waitFor(() => screen.getByTitle(/Input mode/));
+
+    const log = screen.getByRole("log");
+    // mousedown → switches internally to select; mouseup with no selection → cancel
+    fireEvent.mouseDown(log);
+    fireEvent.mouseUp(log);
+
+    // Should be back in input mode (button title says "Input mode")
+    await waitFor(() => {
+      expect(screen.getByTitle(/Input mode/)).toBeTruthy();
+    });
+  });
+
+  it("drag (mousedown + mouseup with selection) switches to select mode", async () => {
+    render(<PreviewPanel agentId="agent-3" />);
+    await waitFor(() => screen.getByTitle(/Input mode/));
+
+    const log = screen.getByRole("log");
+    fireEvent.mouseDown(log);
+
+    // Simulate text being selected before mouseup
+    mockSelection("some selected text");
+    fireEvent.mouseUp(log);
+
+    // Should remain in select mode
+    await waitFor(() => {
+      expect(screen.getByTitle(/Select mode/)).toBeTruthy();
+    });
+  });
+
+  it("click in select mode with no selection returns to input mode", async () => {
+    render(<PreviewPanel agentId="agent-4" />);
+    await waitFor(() => screen.getByTitle(/Input mode/));
+
+    // Enter select mode via button
+    const modeBtn = screen.getByTitle(/Input mode/);
+    fireEvent.click(modeBtn);
+    await waitFor(() => screen.getByTitle(/Select mode/));
+
+    // Click in the log area with no selection
+    const log = screen.getByRole("log");
+    fireEvent.mouseDown(log);
+    fireEvent.mouseUp(log);
+
+    await waitFor(() => {
+      expect(screen.getByTitle(/Input mode/)).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes three bugs in `PreviewPanel` that caused PTY mode UX to differ from tmux mode.

- **Selection mode**: Plain click in input mode permanently locked the user in select mode. `enterSelectMode()` was called on `mousedown`, but the stale `focused` closure in the `onMouseUp` handler always evaluated to `true`, preventing the revert. Introduced `pendingSelectRef` to track mousedown-triggered mode switches; a mouseup with no active selection now cancels them.

- **Scroll during selection**: Auto-scroll called `scrollIntoView` unconditionally, jumping the viewport while the user was drag-selecting text and destroying their selection anchor. Now uses a shared `!hasSelection` guard computed once per effect run, matching the existing guard on `liveRef.current.innerHTML`.

- **Cursor overlay height**: Was hardcoded as `13 * 1.35` px. Now falls back to the measured `getBoundingClientRect().height` of the probe span, so it stays correct if the font stack changes.

## Test plan

- [ ] New test file `PreviewPanel-interaction.test.tsx` (4 cases): starts in input mode, plain click stays in input mode, drag → select mode, click in select mode → input mode
- [ ] All 480 existing tests pass (`pnpm vitest run`)
- [ ] TypeScript type-check clean (`tsc --noEmit`)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)