### PR TITLE
feat: unify mobile web into main WebUI with full responsive support (#5)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,8 +82,16 @@ export function App() {
   } = useSplitPane();
 
   // Responsive layout state (sidebar & action panel collapse)
-  const { sidebarCollapsed, toggleSidebar, actionPanelCollapsed, toggleActionPanel } =
-    useResponsiveLayout();
+  const {
+    sidebarCollapsed,
+    toggleSidebar,
+    actionPanelCollapsed,
+    toggleActionPanel,
+    isMobileScreen,
+    mobileDrawerOpen,
+    toggleMobileDrawer,
+    closeMobileDrawer,
+  } = useResponsiveLayout();
 
   // Fetch registered projects on mount and on demand
   const refreshProjects = useCallback(() => {
@@ -137,12 +145,16 @@ export function App() {
     [refresh, toastSuccess],
   );
 
-  // Select handler for agents
-  const handleSelectAgent = useCallback((target: string) => {
-    setSelection({ type: "agent", id: target });
-    setShowSettings(false);
-    setShowSecurity(false);
-  }, []);
+  // Select handler for agents — closes mobile drawer after selection
+  const handleSelectAgent = useCallback(
+    (target: string) => {
+      setSelection({ type: "agent", id: target });
+      setShowSettings(false);
+      setShowSecurity(false);
+      closeMobileDrawer();
+    },
+    [closeMobileDrawer],
+  );
 
   // Derive selectedTarget string for components that need it
   const selectedTarget = selection?.type === "agent" ? selection.id : null;
@@ -156,18 +168,28 @@ export function App() {
         .split("/")
         .pop() ?? agentProjectPath)
     : null;
+  // Split view is only available on non-mobile, non-narrow screens
   const showSplitView =
-    selection?.type === "agent" && agentProjectPath !== null && splitEnabled && !isNarrowScreen;
+    selection?.type === "agent" &&
+    agentProjectPath !== null &&
+    splitEnabled &&
+    !isNarrowScreen &&
+    !isMobileScreen;
 
-  // Select handler for project branch graph
+  // Select handler for project branch graph — closes mobile drawer
   const handleSelectProject = useCallback(
     (path: string, name: string) => {
       // In split-pane mode with matching project, switch tab instead of going fullscreen
-      if (splitEnabled && !isNarrowScreen && selection?.type === "agent" && agentProjectPath) {
+      if (
+        splitEnabled &&
+        !isNarrowScreen &&
+        !isMobileScreen &&
+        selection?.type === "agent" &&
+        agentProjectPath
+      ) {
         const matchesAgent = path === agentProjectPath;
         if (matchesAgent) {
           if (rightPanelTab === "git") {
-            // Already showing git tab — toggle split view off
             setSplitEnabled(false);
           } else {
             setRightPanelTab("git");
@@ -178,19 +200,34 @@ export function App() {
       setSelection({ type: "project", path, name });
       setShowSettings(false);
       setShowSecurity(false);
+      closeMobileDrawer();
     },
-    [splitEnabled, isNarrowScreen, selection, agentProjectPath, rightPanelTab, setSplitEnabled],
+    [
+      splitEnabled,
+      isNarrowScreen,
+      isMobileScreen,
+      selection,
+      agentProjectPath,
+      rightPanelTab,
+      setSplitEnabled,
+      closeMobileDrawer,
+    ],
   );
 
-  // Select handler for project markdown viewer
+  // Select handler for project markdown viewer — closes mobile drawer
   const handleSelectMarkdown = useCallback(
     (projectPath: string, projectName: string) => {
       // In split-pane mode with matching project, switch tab instead of going fullscreen
-      if (splitEnabled && !isNarrowScreen && selection?.type === "agent" && agentProjectPath) {
+      if (
+        splitEnabled &&
+        !isNarrowScreen &&
+        !isMobileScreen &&
+        selection?.type === "agent" &&
+        agentProjectPath
+      ) {
         const matchesAgent = projectPath === agentProjectPath;
         if (matchesAgent) {
           if (rightPanelTab === "markdown") {
-            // Already showing markdown tab — toggle split view off
             setSplitEnabled(false);
           } else {
             setRightPanelTab("markdown");
@@ -201,8 +238,18 @@ export function App() {
       setSelection({ type: "markdown", projectPath, projectName });
       setShowSettings(false);
       setShowSecurity(false);
+      closeMobileDrawer();
     },
-    [splitEnabled, isNarrowScreen, selection, agentProjectPath, rightPanelTab, setSplitEnabled],
+    [
+      splitEnabled,
+      isNarrowScreen,
+      isMobileScreen,
+      selection,
+      agentProjectPath,
+      rightPanelTab,
+      setSplitEnabled,
+      closeMobileDrawer,
+    ],
   );
 
   // Keyboard shortcuts handlers
@@ -285,78 +332,148 @@ export function App() {
     }
   }, [currentProject, registeredProjects]);
 
+  // Sidebar content shared between desktop sidebar and mobile drawer
+  const sidebarContent = (
+    <>
+      <AgentList
+        agents={aiAgents}
+        loading={loading}
+        selection={selection}
+        onSelectAgent={handleSelectAgent}
+        onSelectProject={handleSelectProject}
+        onSelectMarkdown={handleSelectMarkdown}
+        registeredProjects={registeredProjects}
+        worktrees={worktrees}
+        onSpawned={handleSpawned}
+        splitPaneProjectPath={showSplitView ? agentProjectPath : null}
+        splitPaneTab={showSplitView ? rightPanelTab : null}
+      />
+      <TerminalList
+        terminals={terminals}
+        selectedTarget={selectedTarget}
+        onSelect={handleSelectAgent}
+      />
+      <UsagePanel />
+    </>
+  );
+
   return (
     <div className="flex h-screen text-zinc-100">
-      {/* Sidebar */}
-      <aside
-        className={`glass flex shrink-0 flex-col transition-subtle ${
-          sidebarCollapsed ? "w-14" : "w-80"
-        }`}
-      >
-        <StatusBar
-          agentCount={aiAgents.length}
-          attentionCount={attentionCount}
-          collapsed={sidebarCollapsed}
-          onToggleCollapse={toggleSidebar}
-          onSettingsClick={() => {
-            setShowSettings((v) => !v);
-            setShowSecurity(false);
-          }}
-          onSecurityClick={() => {
-            setShowSecurity((v) => !v);
-            setShowSettings(false);
-          }}
+      {/* Mobile: overlay backdrop when drawer is open */}
+      {isMobileScreen && mobileDrawerOpen && (
+        // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop tap to close
+        // biome-ignore lint/a11y/noStaticElementInteractions: backdrop tap to close
+        <div
+          className="fixed inset-0 z-40 bg-black/60 animate-fade-in"
+          onClick={closeMobileDrawer}
         />
-        {!sidebarCollapsed && (
-          <>
-            <AgentList
-              agents={aiAgents}
-              loading={loading}
-              selection={selection}
-              onSelectAgent={handleSelectAgent}
-              onSelectProject={handleSelectProject}
-              onSelectMarkdown={handleSelectMarkdown}
-              registeredProjects={registeredProjects}
-              worktrees={worktrees}
-              onSpawned={handleSpawned}
-              splitPaneProjectPath={showSplitView ? agentProjectPath : null}
-              splitPaneTab={showSplitView ? rightPanelTab : null}
-            />
-            <TerminalList
-              terminals={terminals}
-              selectedTarget={selectedTarget}
-              onSelect={handleSelectAgent}
-            />
-            <UsagePanel />
-          </>
-        )}
-        {sidebarCollapsed && (
-          <div className="flex flex-1 flex-col items-center gap-1 overflow-y-auto py-2">
-            {aiAgents.map((agent) => (
-              <button
-                key={agent.id}
-                type="button"
-                onClick={() => handleSelectAgent(agent.target)}
-                className={`h-8 w-8 rounded-lg text-[10px] transition-colors ${
-                  selectedTarget === agent.target
-                    ? "bg-cyan-500/20 text-cyan-400"
-                    : "text-zinc-500 hover:bg-white/10 hover:text-zinc-300"
-                }`}
-                title={agent.target}
+      )}
+
+      {/* Mobile drawer (off-canvas) */}
+      {isMobileScreen && (
+        <div
+          className={`fixed inset-y-0 left-0 z-50 flex w-80 flex-col glass border-r border-white/5 transition-transform duration-300 ease-out safe-top safe-bottom ${
+            mobileDrawerOpen ? "translate-x-0" : "-translate-x-full"
+          }`}
+        >
+          <div className="flex items-center justify-between border-b border-white/5 px-4 py-3">
+            <span className="bg-gradient-to-r from-cyan-400 to-blue-400 bg-clip-text text-sm font-bold tracking-wide text-transparent">
+              tmai
+            </span>
+            <button
+              type="button"
+              onClick={closeMobileDrawer}
+              className="touch-target flex items-center justify-center rounded-lg text-zinc-500 transition-colors hover:bg-white/10 hover:text-zinc-300"
+              title="Close navigation"
+              aria-label="Close navigation"
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 16 16"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
               >
-                {statusName(agent.status) === "Processing"
-                  ? "●"
-                  : statusName(agent.status) === "AwaitingApproval"
-                    ? "◐"
-                    : "○"}
-              </button>
-            ))}
+                <title>Close</title>
+                <path d="M3 3l10 10M13 3L3 13" />
+              </svg>
+            </button>
           </div>
-        )}
-      </aside>
+          <div className="flex flex-1 flex-col overflow-y-auto">{sidebarContent}</div>
+        </div>
+      )}
+
+      {/* Desktop sidebar (not shown on mobile) */}
+      {!isMobileScreen && (
+        <aside
+          className={`glass flex shrink-0 flex-col transition-subtle ${
+            sidebarCollapsed ? "w-14" : "w-80"
+          }`}
+        >
+          <StatusBar
+            agentCount={aiAgents.length}
+            attentionCount={attentionCount}
+            collapsed={sidebarCollapsed}
+            onToggleCollapse={toggleSidebar}
+            onSettingsClick={() => {
+              setShowSettings((v) => !v);
+              setShowSecurity(false);
+            }}
+            onSecurityClick={() => {
+              setShowSecurity((v) => !v);
+              setShowSettings(false);
+            }}
+          />
+          {!sidebarCollapsed && (
+            <div className="flex flex-1 flex-col overflow-y-auto">{sidebarContent}</div>
+          )}
+          {sidebarCollapsed && (
+            <div className="flex flex-1 flex-col items-center gap-1 overflow-y-auto py-2">
+              {aiAgents.map((agent) => (
+                <button
+                  key={agent.id}
+                  type="button"
+                  onClick={() => handleSelectAgent(agent.target)}
+                  className={`h-8 w-8 rounded-lg text-[10px] transition-colors ${
+                    selectedTarget === agent.target
+                      ? "bg-cyan-500/20 text-cyan-400"
+                      : "text-zinc-500 hover:bg-white/10 hover:text-zinc-300"
+                  }`}
+                  title={agent.target}
+                >
+                  {statusName(agent.status) === "Processing"
+                    ? "●"
+                    : statusName(agent.status) === "AwaitingApproval"
+                      ? "◐"
+                      : "○"}
+                </button>
+              ))}
+            </div>
+          )}
+        </aside>
+      )}
 
       {/* Main area */}
       <main className="flex flex-1 flex-col overflow-hidden transition-subtle">
+        {/* Mobile top bar */}
+        {isMobileScreen && (
+          <StatusBar
+            agentCount={aiAgents.length}
+            attentionCount={attentionCount}
+            isMobile
+            onMobileMenuClick={toggleMobileDrawer}
+            onSettingsClick={() => {
+              setShowSettings((v) => !v);
+              setShowSecurity(false);
+            }}
+            onSecurityClick={() => {
+              setShowSecurity((v) => !v);
+              setShowSettings(false);
+            }}
+          />
+        )}
+
         {showSecurity ? (
           <div className="flex flex-1 flex-col overflow-hidden animate-scale-in">
             <SecurityPanel onClose={() => setShowSecurity(false)} />
@@ -377,8 +494,8 @@ export function App() {
               worktrees={worktrees}
               agents={aiAgents}
               onFocusAgent={handleSelectAgent}
-              actionPanelCollapsed={actionPanelCollapsed}
-              onToggleActionPanel={toggleActionPanel}
+              actionPanelCollapsed={actionPanelCollapsed || isMobileScreen}
+              onToggleActionPanel={isMobileScreen ? undefined : toggleActionPanel}
             />
           </div>
         ) : selection?.type === "markdown" ? (
@@ -467,14 +584,18 @@ export function App() {
               </div>
             ) : (
               <div className="flex flex-1 items-center justify-center animate-fade-in">
-                <div className="glass-light rounded-2xl px-12 py-10 text-center transition-subtle hover:glass">
+                <div className="glass-light rounded-2xl px-8 py-8 text-center transition-subtle hover:glass mx-4">
                   <h1 className="bg-gradient-to-r from-cyan-400 to-blue-500 bg-clip-text text-3xl font-bold tracking-tight text-transparent">
                     tmai
                   </h1>
                   <p className="mt-2 text-sm text-zinc-500">
                     {agents.length > 0
-                      ? "Select an agent to view • Press ? for shortcuts"
-                      : "Click + on a project to spawn an agent • Press ? for shortcuts"}
+                      ? isMobileScreen
+                        ? "Tap ☰ to select an agent"
+                        : "Select an agent to view • Press ? for shortcuts"
+                      : isMobileScreen
+                        ? "Tap ☰ then + on a project to spawn an agent"
+                        : "Click + on a project to spawn an agent • Press ? for shortcuts"}
                   </p>
                 </div>
               </div>

--- a/src/components/agent/AgentActions.tsx
+++ b/src/components/agent/AgentActions.tsx
@@ -45,11 +45,11 @@ export function AgentActions({ agent, passthrough }: AgentActionsProps) {
   }, [needsPermission, handleApprove]);
 
   return (
-    <div className="glass flex items-center gap-2 border-0 border-b border-white/5 px-3 py-2">
-      <span className="text-sm font-medium text-zinc-300">{agent.display_name}</span>
+    <div className="glass flex flex-wrap items-center gap-2 border-0 border-b border-white/5 px-3 py-2">
+      <span className="truncate text-sm font-medium text-zinc-300">{agent.display_name}</span>
       <span
         className={cn(
-          "rounded px-1.5 py-0.5 text-xs",
+          "shrink-0 rounded px-1.5 py-0.5 text-xs",
           needsPermission && "bg-red-500/20 text-red-400",
           isProcessing && "bg-cyan-500/20 text-cyan-400",
           isIdle && "bg-zinc-500/20 text-zinc-400",
@@ -66,7 +66,7 @@ export function AgentActions({ agent, passthrough }: AgentActionsProps) {
           <button
             type="button"
             onClick={handleApprove}
-            className="rounded-md bg-emerald-500/20 px-3 py-1 text-xs font-medium text-emerald-400 transition-colors hover:bg-emerald-500/30"
+            className="touch-target-sm rounded-md bg-emerald-500/20 px-3 py-1.5 text-xs font-medium text-emerald-400 transition-colors hover:bg-emerald-500/30"
             title="Ctrl+Enter"
           >
             Approve
@@ -74,7 +74,7 @@ export function AgentActions({ agent, passthrough }: AgentActionsProps) {
           <button
             type="button"
             onClick={handleReject}
-            className="glass-card rounded-md px-3 py-1 text-xs font-medium text-zinc-300 transition-colors"
+            className="touch-target-sm glass-card rounded-md px-3 py-1.5 text-xs font-medium text-zinc-300 transition-colors"
           >
             Reject
           </button>
@@ -84,7 +84,7 @@ export function AgentActions({ agent, passthrough }: AgentActionsProps) {
       <button
         type="button"
         onClick={handleKill}
-        className="rounded-md px-2 py-1 text-xs text-zinc-600 transition-colors hover:text-red-400"
+        className="touch-target-sm rounded-md px-2 py-1.5 text-xs text-zinc-600 transition-colors hover:text-red-400"
         title="Kill agent"
       >
         Kill

--- a/src/components/agent/PreviewPanel.tsx
+++ b/src/components/agent/PreviewPanel.tsx
@@ -779,12 +779,12 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
       )}
 
       {/* Footer status bar */}
-      <div className="flex items-center gap-2 border-t border-white/5 px-3 py-1">
+      <div className="flex items-center gap-2 border-t border-white/5 px-3 py-1.5">
         <button
           type="button"
           onMouseDown={(e) => e.preventDefault()}
           onClick={focused ? enterSelectMode : enterInputMode}
-          className={`rounded px-1.5 py-0.5 text-[10px] transition-colors ${
+          className={`touch-target-sm rounded px-2 py-1 text-xs transition-colors ${
             focused ? "bg-cyan-500/20 text-cyan-400" : "bg-amber-500/20 text-amber-400"
           }`}
           title={
@@ -799,7 +799,7 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
           type="button"
           onMouseDown={(e) => e.preventDefault()}
           onClick={() => setAutoScroll((v) => !v)}
-          className={`rounded px-1.5 py-0.5 text-[10px] transition-colors ${
+          className={`touch-target-sm rounded px-2 py-1 text-xs transition-colors ${
             autoScroll
               ? "bg-cyan-500/15 text-cyan-400"
               : "bg-white/5 text-zinc-600 hover:text-zinc-400"
@@ -812,7 +812,7 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
           type="button"
           onMouseDown={(e) => e.preventDefault()}
           onClick={() => setShowCursor((v) => !v)}
-          className={`rounded px-1.5 py-0.5 text-[10px] transition-colors ${
+          className={`touch-target-sm rounded px-2 py-1 text-xs transition-colors ${
             showCursor
               ? "bg-cyan-500/15 text-cyan-400"
               : "bg-white/5 text-zinc-600 hover:text-zinc-400"
@@ -848,7 +848,7 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
           />
         </div>
         <div className="flex-1" />
-        <span className="text-[10px] text-zinc-600">
+        <span className="hidden text-[10px] text-zinc-600 sm:block">
           {focused ? "click to select" : "Enter or click ⌨ to input"}
         </span>
       </div>

--- a/src/components/agent/__tests__/PreviewPanel-interaction.test.tsx
+++ b/src/components/agent/__tests__/PreviewPanel-interaction.test.tsx
@@ -1,7 +1,6 @@
 // @vitest-environment jsdom
 // Tests for PTY mode conversation panel selection / scroll UX (#4).
-import { render, screen, waitFor } from "@testing-library/react";
-import { fireEvent } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 global.ResizeObserver = class ResizeObserver {

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -5,6 +5,9 @@ interface StatusBarProps {
   onToggleCollapse?: () => void;
   onSettingsClick: () => void;
   onSecurityClick: () => void;
+  /** Mobile: show hamburger button instead of collapse arrow */
+  isMobile?: boolean;
+  onMobileMenuClick?: () => void;
 }
 
 // Top status bar with glassmorphism
@@ -15,7 +18,64 @@ export function StatusBar({
   onToggleCollapse,
   onSettingsClick,
   onSecurityClick,
+  isMobile,
+  onMobileMenuClick,
 }: StatusBarProps) {
+  if (isMobile) {
+    return (
+      <div className="flex items-center justify-between border-b border-white/5 px-3 py-2">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onMobileMenuClick}
+            className="touch-target flex items-center justify-center rounded-lg text-zinc-400 transition-colors hover:bg-white/10 hover:text-cyan-400"
+            title="Open navigation"
+            aria-label="Open navigation menu"
+          >
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 20 20"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+            >
+              <title>Menu</title>
+              <path d="M3 5h14M3 10h14M3 15h14" />
+            </svg>
+          </button>
+          <span className="bg-gradient-to-r from-cyan-400 to-blue-400 bg-clip-text text-sm font-bold tracking-wide text-transparent">
+            tmai
+          </span>
+          {attentionCount > 0 && (
+            <span className="glow-amber rounded-full bg-amber-500/15 px-2 py-0.5 text-xs text-amber-400">
+              {attentionCount}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={onSecurityClick}
+            className="touch-target flex items-center justify-center rounded-lg text-zinc-500 transition-colors hover:bg-white/10 hover:text-cyan-400"
+            title="Config Audit"
+          >
+            🛡
+          </button>
+          <button
+            type="button"
+            onClick={onSettingsClick}
+            className="touch-target flex items-center justify-center rounded-lg text-zinc-500 transition-colors hover:bg-white/10 hover:text-cyan-400"
+            title="Settings"
+          >
+            ⚙
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   if (collapsed) {
     return (
       <div className="flex flex-col items-center gap-2 border-b border-white/5 px-2 py-3">

--- a/src/components/markdown/MarkdownPanel.tsx
+++ b/src/components/markdown/MarkdownPanel.tsx
@@ -47,6 +47,8 @@ export function MarkdownPanel({ projectPath, projectName }: MarkdownPanelProps) 
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [editable, setEditable] = useState(false);
+  // Mobile: file tree panel open/closed
+  const [treeOpen, setTreeOpen] = useState(false);
 
   // Fetch file tree
   useEffect(() => {
@@ -64,6 +66,7 @@ export function MarkdownPanel({ projectPath, projectName }: MarkdownPanelProps) 
     setEditing(false);
     setSaveError(null);
     setFileLoading(true);
+    setTreeOpen(false); // Close tree drawer after selecting on mobile
     api
       .readFile(path)
       .then((data) => {
@@ -99,17 +102,52 @@ export function MarkdownPanel({ projectPath, projectName }: MarkdownPanelProps) 
     }
   }, [tree, selectedFile, loadFile]);
 
+  const fileTree = (
+    <>
+      {loading ? (
+        <div className="px-3 py-2 text-xs text-zinc-500">Loading...</div>
+      ) : tree.length === 0 ? (
+        <div className="px-3 py-2 text-xs text-zinc-500">No markdown files</div>
+      ) : (
+        <TreeNode entries={tree} selectedFile={selectedFile} onSelect={loadFile} depth={0} />
+      )}
+    </>
+  );
+
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
       {/* Header */}
-      <div className="glass shrink-0 border-b border-white/5 px-6 py-4">
+      <div className="glass shrink-0 border-b border-white/5 px-4 py-3">
         <div className="flex items-center gap-3">
+          {/* Mobile: toggle file tree button */}
+          <button
+            type="button"
+            onClick={() => setTreeOpen((v) => !v)}
+            className="touch-target flex items-center justify-center rounded-lg text-zinc-500 transition-colors hover:bg-white/10 hover:text-zinc-300 md:hidden"
+            title="Toggle file list"
+            aria-label="Toggle file list"
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+            >
+              <title>Files</title>
+              <rect x="2" y="2" width="5" height="5" rx="0.5" />
+              <rect x="9" y="2" width="5" height="5" rx="0.5" />
+              <rect x="2" y="9" width="5" height="5" rx="0.5" />
+              <rect x="9" y="9" width="5" height="5" rx="0.5" />
+            </svg>
+          </button>
           <svg
             width="20"
             height="20"
             viewBox="0 0 16 16"
             fill="none"
-            className="text-blue-400"
+            className="hidden shrink-0 text-blue-400 md:block"
             role="img"
             aria-label="Document icon"
           >
@@ -152,28 +190,37 @@ export function MarkdownPanel({ projectPath, projectName }: MarkdownPanelProps) 
               opacity="0.5"
             />
           </svg>
-          <h2 className="text-lg font-semibold text-zinc-100">{projectName}</h2>
-          <span className="text-xs text-zinc-500">Markdown</span>
+          <h2 className="truncate text-base font-semibold text-zinc-100">{projectName}</h2>
+          <span className="shrink-0 text-xs text-zinc-500">Markdown</span>
         </div>
       </div>
 
-      <div className="flex flex-1 overflow-hidden">
-        {/* Left: File tree */}
-        <div className="w-56 shrink-0 overflow-y-auto border-r border-white/5 bg-black/10 py-2">
-          {loading ? (
-            <div className="px-3 py-2 text-xs text-zinc-500">Loading...</div>
-          ) : tree.length === 0 ? (
-            <div className="px-3 py-2 text-xs text-zinc-500">No markdown files</div>
-          ) : (
-            <TreeNode entries={tree} selectedFile={selectedFile} onSelect={loadFile} depth={0} />
-          )}
+      <div className="relative flex flex-1 overflow-hidden">
+        {/* Mobile: file tree as overlay drawer */}
+        {treeOpen && (
+          <>
+            {/* biome-ignore lint/a11y/useKeyWithClickEvents: backdrop tap to close */}
+            {/* biome-ignore lint/a11y/noStaticElementInteractions: backdrop tap to close */}
+            <div
+              className="absolute inset-0 z-10 bg-black/50 md:hidden"
+              onClick={() => setTreeOpen(false)}
+            />
+            <div className="absolute inset-y-0 left-0 z-20 w-56 overflow-y-auto border-r border-white/5 bg-zinc-950 py-2 md:hidden animate-slide-in-left">
+              {fileTree}
+            </div>
+          </>
+        )}
+
+        {/* Desktop: file tree as persistent sidebar */}
+        <div className="hidden w-56 shrink-0 overflow-y-auto border-r border-white/5 bg-black/10 py-2 md:block">
+          {fileTree}
         </div>
 
         {/* Right: Preview / Editor */}
         <div className="flex flex-1 flex-col overflow-auto">
           {!selectedFile ? (
             <div className="flex items-center justify-center py-20 text-sm text-zinc-500">
-              Select a file to preview
+              {treeOpen ? null : "Select a file to preview"}
             </div>
           ) : fileLoading ? (
             <div className="flex items-center justify-center py-20 text-sm text-zinc-500">
@@ -190,7 +237,7 @@ export function MarkdownPanel({ projectPath, projectName }: MarkdownPanelProps) 
                   type="button"
                   onClick={handleSave}
                   disabled={saving}
-                  className="rounded bg-blue-500/20 px-3 py-1 text-xs text-blue-400 hover:bg-blue-500/30 disabled:opacity-50"
+                  className="touch-target-sm rounded bg-blue-500/20 px-3 py-1 text-xs text-blue-400 hover:bg-blue-500/30 disabled:opacity-50"
                 >
                   {saving ? "Saving..." : "Save"}
                 </button>
@@ -201,7 +248,7 @@ export function MarkdownPanel({ projectPath, projectName }: MarkdownPanelProps) 
                     setEditContent(content);
                     setSaveError(null);
                   }}
-                  className="rounded bg-white/5 px-3 py-1 text-xs text-zinc-400 hover:bg-white/10"
+                  className="touch-target-sm rounded bg-white/5 px-3 py-1 text-xs text-zinc-400 hover:bg-white/10"
                 >
                   Cancel
                 </button>
@@ -214,7 +261,7 @@ export function MarkdownPanel({ projectPath, projectName }: MarkdownPanelProps) 
               <textarea
                 value={editContent}
                 onChange={(e) => setEditContent(e.target.value)}
-                className="flex-1 resize-none bg-transparent px-6 py-4 font-mono text-sm text-zinc-200 outline-none"
+                className="flex-1 resize-none bg-transparent px-4 py-4 font-mono text-sm text-zinc-200 outline-none md:px-6"
                 spellCheck={false}
               />
             </div>
@@ -229,7 +276,7 @@ export function MarkdownPanel({ projectPath, projectName }: MarkdownPanelProps) 
                   <button
                     type="button"
                     onClick={() => setEditing(true)}
-                    className="rounded bg-white/5 px-3 py-1 text-xs text-zinc-400 hover:bg-white/10 hover:text-zinc-200"
+                    className="touch-target-sm rounded bg-white/5 px-3 py-1 text-xs text-zinc-400 hover:bg-white/10 hover:text-zinc-200"
                   >
                     Edit
                   </button>
@@ -238,7 +285,7 @@ export function MarkdownPanel({ projectPath, projectName }: MarkdownPanelProps) 
                 )}
               </div>
               {/* Content: markdown preview or code view */}
-              <div className="flex-1 overflow-auto px-6 py-4">
+              <div className="flex-1 overflow-auto px-4 py-4 md:px-6">
                 {selectedFile.endsWith(".md") ? (
                   <div
                     className="prose prose-invert prose-sm max-w-none
@@ -247,7 +294,7 @@ export function MarkdownPanel({ projectPath, projectName }: MarkdownPanelProps) 
                     prose-a:text-blue-400 prose-a:no-underline hover:prose-a:underline
                     prose-strong:text-zinc-200
                     prose-code:text-cyan-400 prose-code:bg-white/5 prose-code:rounded prose-code:px-1 prose-code:py-0.5 prose-code:text-xs prose-code:before:content-none prose-code:after:content-none
-                    prose-pre:bg-zinc-900/50 prose-pre:border prose-pre:border-white/5 prose-pre:rounded-lg
+                    prose-pre:bg-zinc-900/50 prose-pre:border prose-pre:border-white/5 prose-pre:rounded-lg prose-pre:overflow-x-auto
                     prose-li:text-zinc-300
                     prose-th:text-zinc-300 prose-th:border-white/10
                     prose-td:text-zinc-400 prose-td:border-white/10
@@ -329,8 +376,8 @@ function TreeNode({
                     return next;
                   })
                 }
-                className="flex w-full items-center gap-1 px-2 py-1 text-left text-[11px] text-zinc-500 hover:text-zinc-300 transition-colors"
-                style={{ paddingLeft: 8 + depth * 12 }}
+                className="flex w-full items-center gap-1 py-1.5 text-left text-[11px] text-zinc-500 hover:text-zinc-300 transition-colors"
+                style={{ paddingLeft: 8 + depth * 12, paddingRight: 8 }}
               >
                 <span className="text-[9px]">{isCollapsed ? "\u25B8" : "\u25BE"}</span>
                 <span className="truncate">{entry.name}</span>
@@ -352,14 +399,14 @@ function TreeNode({
             type="button"
             key={entry.path}
             onClick={() => onSelect(entry.path)}
-            className={`flex w-full items-center gap-1.5 px-2 py-1 text-left text-[11px] transition-colors ${
+            className={`flex w-full items-center gap-1.5 py-1.5 text-left text-[11px] transition-colors ${
               isSelected
                 ? "bg-blue-500/10 text-blue-400"
                 : entry.openable
                   ? "text-zinc-400 hover:bg-white/5 hover:text-zinc-200"
                   : "text-zinc-600 hover:bg-white/[0.03] hover:text-zinc-400"
             }`}
-            style={{ paddingLeft: 8 + depth * 12 }}
+            style={{ paddingLeft: 8 + depth * 12, paddingRight: 8 }}
           >
             <span
               className={`shrink-0 text-[10px] ${

--- a/src/components/terminal/TerminalPanel.tsx
+++ b/src/components/terminal/TerminalPanel.tsx
@@ -47,7 +47,7 @@ export function TerminalPanel({ sessionId }: TerminalPanelProps) {
       <div className="flex items-center justify-between border-b border-zinc-800 px-3 py-1.5">
         <span className="text-xs text-zinc-500">{sessionId.slice(0, 8)}</span>
       </div>
-      {/* biome-ignore lint/a11y/noStaticElementInteractions: terminal container needs mouse events for selection mode */}
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: terminal container needs pointer events for selection mode */}
       <div
         ref={containerRef}
         className="flex-1 overflow-hidden bg-[#09090b] p-1"
@@ -62,15 +62,19 @@ export function TerminalPanel({ sessionId }: TerminalPanelProps) {
             }
           }
         }}
+        onTouchStart={() => {
+          // On touch, switch to select mode so text is selectable/copyable
+          if (inputMode) enterSelectMode();
+        }}
       />
 
-      {/* Footer status bar — same pattern as PreviewPanel */}
-      <div className="flex items-center gap-2 border-t border-white/5 px-3 py-1">
+      {/* Footer status bar */}
+      <div className="flex items-center gap-2 border-t border-white/5 px-3 py-1.5">
         <button
           type="button"
           onMouseDown={(e) => e.preventDefault()}
           onClick={inputMode ? enterSelectMode : enterInputMode}
-          className={`rounded px-1.5 py-0.5 text-[10px] transition-colors ${
+          className={`touch-target-sm rounded px-2 py-1 text-xs transition-colors ${
             inputMode ? "bg-cyan-500/20 text-cyan-400" : "bg-amber-500/20 text-amber-400"
           }`}
           title={
@@ -85,7 +89,7 @@ export function TerminalPanel({ sessionId }: TerminalPanelProps) {
           type="button"
           onMouseDown={(e) => e.preventDefault()}
           onClick={() => setAutoScroll((v) => !v)}
-          className={`rounded px-1.5 py-0.5 text-[10px] transition-colors ${
+          className={`touch-target-sm rounded px-2 py-1 text-xs transition-colors ${
             autoScroll
               ? "bg-cyan-500/15 text-cyan-400"
               : "bg-white/5 text-zinc-600 hover:text-zinc-400"
@@ -95,7 +99,7 @@ export function TerminalPanel({ sessionId }: TerminalPanelProps) {
           {autoScroll ? "⇩ Auto" : "⇩ Off"}
         </button>
         <div className="flex-1" />
-        <span className="text-[10px] text-zinc-600">
+        <span className="hidden text-[10px] text-zinc-600 sm:block">
           {inputMode ? "click to select" : "Enter or click ⌨ to input"}
         </span>
       </div>

--- a/src/components/worktree/BranchGraph.tsx
+++ b/src/components/worktree/BranchGraph.tsx
@@ -542,14 +542,15 @@ export function BranchGraph({
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
       {/* Header */}
-      <div className="glass shrink-0 border-b border-white/5 px-6 py-4">
-        <div className="flex items-center gap-3">
+      <div className="glass shrink-0 border-b border-white/5 px-4 py-3 md:px-6 md:py-4">
+        {/* Row 1: icon + name + tab switcher */}
+        <div className="flex flex-wrap items-center gap-2">
           <svg
-            width="20"
-            height="20"
+            width="18"
+            height="18"
             viewBox="0 0 16 16"
             fill="none"
-            className="text-emerald-400"
+            className="shrink-0 text-emerald-400"
             role="img"
             aria-label="Branch graph"
           >
@@ -560,7 +561,9 @@ export function BranchGraph({
             <line x1="4" y1="6" x2="4" y2="10" stroke="currentColor" strokeWidth="1.5" />
             <path d="M4 6 C4 8, 8 8, 12 8" stroke="currentColor" strokeWidth="1.5" fill="none" />
           </svg>
-          <h2 className="text-lg font-semibold text-zinc-100">{projectName}</h2>
+          <h2 className="truncate text-base font-semibold text-zinc-100 md:text-lg">
+            {projectName}
+          </h2>
           {/* Tab switcher */}
           <div className="flex gap-1 rounded-lg bg-white/5 p-0.5">
             <button
@@ -569,7 +572,7 @@ export function BranchGraph({
                 setShowIssues(false);
                 setSelectedIssue(null);
               }}
-              className={`rounded-md px-2.5 py-1 text-xs transition-colors ${
+              className={`touch-target-sm rounded-md px-2.5 py-1 text-xs transition-colors ${
                 !showIssues ? "bg-white/10 text-zinc-200" : "text-zinc-500 hover:text-zinc-300"
               }`}
             >
@@ -578,60 +581,62 @@ export function BranchGraph({
             <button
               type="button"
               onClick={() => setShowIssues(true)}
-              className={`rounded-md px-2.5 py-1 text-xs transition-colors ${
+              className={`touch-target-sm rounded-md px-2.5 py-1 text-xs transition-colors ${
                 showIssues ? "bg-white/10 text-zinc-200" : "text-zinc-500 hover:text-zinc-300"
               }`}
             >
               Issues{issues.length > 0 ? ` (${issues.length})` : ""}
             </button>
           </div>
-          <span className="text-xs text-zinc-500">
-            {!showIssues && (
-              <>
-                {branchCount} branch{branchCount !== 1 ? "es" : ""}
-                {(() => {
-                  const wtCount = projectWorktrees.filter((w) => !w.is_main).length;
-                  if (wtCount === 0) return null;
-                  return ` (${wtCount} worktree${wtCount !== 1 ? "s" : ""})`;
-                })()}
-                {graphData && (
-                  <>
-                    {" \u00B7 "}
-                    {graphData.total_count} commit
-                    {graphData.total_count !== 1 ? "s" : ""}
-                  </>
-                )}
-              </>
-            )}
-          </span>
           <div className="flex-1" />
-          {branches?.last_fetch && (
-            <span
-              className="text-[10px] text-zinc-600"
-              title={new Date(branches.last_fetch * 1000).toLocaleString()}
-            >
-              fetched {formatRelativeTime(branches.last_fetch)}
-            </span>
-          )}
-          {!showIssues && mergedBranches.length > 0 && (
+          {/* Action buttons */}
+          <div className="flex items-center gap-1.5">
+            {branches?.last_fetch && (
+              <span
+                className="hidden text-[10px] text-zinc-600 md:block"
+                title={new Date(branches.last_fetch * 1000).toLocaleString()}
+              >
+                fetched {formatRelativeTime(branches.last_fetch)}
+              </span>
+            )}
+            {!showIssues && mergedBranches.length > 0 && (
+              <button
+                type="button"
+                onClick={handleBulkDeleteMerged}
+                disabled={bulkDeleteBusy}
+                className="touch-target-sm rounded-lg bg-red-500/10 px-2.5 py-1.5 text-xs text-red-400 transition-colors hover:bg-red-500/20 hover:text-red-300 disabled:opacity-50"
+              >
+                {bulkDeleteBusy ? "Deleting..." : `Delete Merged (${mergedBranches.length})`}
+              </button>
+            )}
             <button
               type="button"
-              onClick={handleBulkDeleteMerged}
-              disabled={bulkDeleteBusy}
-              className="rounded-lg bg-red-500/10 px-3 py-1.5 text-xs text-red-400 transition-colors hover:bg-red-500/20 hover:text-red-300 disabled:opacity-50"
+              onClick={handleRefresh}
+              disabled={refreshBusy}
+              className="touch-target-sm rounded-lg bg-white/5 px-2.5 py-1.5 text-xs text-zinc-400 transition-colors hover:bg-white/10 hover:text-zinc-200 disabled:opacity-50"
             >
-              {bulkDeleteBusy ? "Deleting..." : `Delete Merged (${mergedBranches.length})`}
+              {refreshBusy ? "..." : "Refresh"}
             </button>
-          )}
-          <button
-            type="button"
-            onClick={handleRefresh}
-            disabled={refreshBusy}
-            className="rounded-lg bg-white/5 px-3 py-1.5 text-xs text-zinc-400 transition-colors hover:bg-white/10 hover:text-zinc-200 disabled:opacity-50"
-          >
-            {refreshBusy ? "..." : "Refresh"}
-          </button>
+          </div>
         </div>
+        {/* Row 2: stats (hidden on smallest screens) */}
+        {!showIssues && (
+          <div className="mt-1 hidden text-xs text-zinc-500 sm:block">
+            {branchCount} branch{branchCount !== 1 ? "es" : ""}
+            {(() => {
+              const wtCount = projectWorktrees.filter((w) => !w.is_main).length;
+              if (wtCount === 0) return null;
+              return ` (${wtCount} worktree${wtCount !== 1 ? "s" : ""})`;
+            })()}
+            {graphData && (
+              <>
+                {" \u00B7 "}
+                {graphData.total_count} commit
+                {graphData.total_count !== 1 ? "s" : ""}
+              </>
+            )}
+          </div>
+        )}
         {refreshError && <div className="mt-2 text-xs text-red-400">{refreshError}</div>}
       </div>
 

--- a/src/components/worktree/WorktreePanel.tsx
+++ b/src/components/worktree/WorktreePanel.tsx
@@ -70,17 +70,17 @@ export function WorktreePanel({ worktree, onLaunched, onDeleted }: WorktreePanel
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
       {/* Header */}
-      <div className="glass shrink-0 border-b border-white/5 px-6 py-4">
-        <div className="flex items-center justify-between">
-          <div>
+      <div className="glass shrink-0 border-b border-white/5 px-4 py-3 md:px-6 md:py-4">
+        <div className="flex flex-wrap items-start justify-between gap-2">
+          <div className="min-w-0">
             <div className="flex items-center gap-2">
               <span className="text-emerald-500">🌿</span>
-              <h2 className="text-lg font-semibold text-zinc-100">
+              <h2 className="truncate text-base font-semibold text-zinc-100 md:text-lg">
                 {worktree.branch || worktree.name}
               </h2>
-              {worktree.is_dirty && <span className="text-sm text-amber-500">*</span>}
+              {worktree.is_dirty && <span className="shrink-0 text-sm text-amber-500">*</span>}
             </div>
-            <div className="mt-1 flex items-center gap-3 text-xs text-zinc-500">
+            <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-zinc-500">
               {ds && (
                 <span>
                   <span className="text-emerald-400">+{ds.insertions}</span>{" "}
@@ -96,19 +96,19 @@ export function WorktreePanel({ worktree, onLaunched, onDeleted }: WorktreePanel
               )}
             </div>
           </div>
-          <div className="flex items-center gap-2 text-xs text-zinc-500">
+          <div className="shrink-0 text-xs text-zinc-500">
             <span className="font-mono">{worktree.repo_name}</span>
           </div>
         </div>
 
         {/* Actions */}
-        <div className="mt-3 flex items-center gap-2">
+        <div className="mt-3 flex flex-wrap items-center gap-2">
           {!hasAgent && (
             <button
               type="button"
               onClick={handleLaunch}
               disabled={launching}
-              className="rounded-lg bg-cyan-500/15 px-3 py-1.5 text-xs font-medium text-cyan-400 transition-colors hover:bg-cyan-500/25 disabled:opacity-50"
+              className="touch-target-sm rounded-lg bg-cyan-500/15 px-3 py-1.5 text-xs font-medium text-cyan-400 transition-colors hover:bg-cyan-500/25 disabled:opacity-50"
             >
               {launching ? "Launching..." : "Launch Agent"}
             </button>
@@ -117,12 +117,12 @@ export function WorktreePanel({ worktree, onLaunched, onDeleted }: WorktreePanel
             <button
               type="button"
               onClick={() => setConfirmDelete(true)}
-              className="rounded-lg bg-red-500/10 px-3 py-1.5 text-xs font-medium text-red-400 transition-colors hover:bg-red-500/20"
+              className="touch-target-sm rounded-lg bg-red-500/10 px-3 py-1.5 text-xs font-medium text-red-400 transition-colors hover:bg-red-500/20"
             >
               Delete
             </button>
           ) : (
-            <div className="flex items-center gap-2 rounded-lg border border-red-500/20 bg-red-500/5 px-3 py-1.5">
+            <div className="flex flex-wrap items-center gap-2 rounded-lg border border-red-500/20 bg-red-500/5 px-3 py-2">
               <label className="flex items-center gap-1.5 text-[11px] text-zinc-400">
                 <input
                   type="checkbox"
@@ -136,7 +136,7 @@ export function WorktreePanel({ worktree, onLaunched, onDeleted }: WorktreePanel
                 type="button"
                 onClick={handleDelete}
                 disabled={deleting}
-                className="rounded bg-red-500/20 px-2 py-0.5 text-xs text-red-400 transition-colors hover:bg-red-500/30 disabled:opacity-50"
+                className="touch-target-sm rounded bg-red-500/20 px-2 py-1 text-xs text-red-400 transition-colors hover:bg-red-500/30 disabled:opacity-50"
               >
                 {deleting ? "Deleting..." : "Confirm"}
               </button>
@@ -146,7 +146,7 @@ export function WorktreePanel({ worktree, onLaunched, onDeleted }: WorktreePanel
                   setConfirmDelete(false);
                   setForceDelete(false);
                 }}
-                className="text-xs text-zinc-500 transition-colors hover:text-zinc-300"
+                className="touch-target-sm text-xs text-zinc-500 transition-colors hover:text-zinc-300"
               >
                 Cancel
               </button>
@@ -156,7 +156,7 @@ export function WorktreePanel({ worktree, onLaunched, onDeleted }: WorktreePanel
             type="button"
             onClick={fetchDiff}
             disabled={diffLoading}
-            className="rounded-lg bg-white/5 px-3 py-1.5 text-xs text-zinc-400 transition-colors hover:bg-white/10 disabled:opacity-50"
+            className="touch-target-sm rounded-lg bg-white/5 px-3 py-1.5 text-xs text-zinc-400 transition-colors hover:bg-white/10 disabled:opacity-50"
           >
             {diffLoading ? "Loading..." : "Refresh Diff"}
           </button>

--- a/src/hooks/useResponsiveLayout.ts
+++ b/src/hooks/useResponsiveLayout.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from "react";
 const STORAGE_KEY_SIDEBAR = "tmai:sidebar-collapsed";
 const STORAGE_KEY_ACTION_PANEL = "tmai:action-panel-collapsed";
 const NARROW_BREAKPOINT = "(min-width: 1024px)";
+const MOBILE_BREAKPOINT = "(min-width: 768px)";
 
 // Read a boolean from localStorage with a fallback default
 function readStoredBool(key: string, fallback: boolean): boolean {
@@ -21,13 +22,24 @@ export interface UseResponsiveLayoutResult {
   actionPanelCollapsed: boolean;
   toggleActionPanel: () => void;
   isNarrowScreen: boolean;
+  /** true when viewport width < 768px — triggers mobile drawer/overlay layout */
+  isMobileScreen: boolean;
+  /** Mobile sidebar drawer open state (separate from desktop collapsed state) */
+  mobileDrawerOpen: boolean;
+  toggleMobileDrawer: () => void;
+  closeMobileDrawer: () => void;
 }
 
-// Manage responsive layout state: sidebar collapse, action panel collapse, narrow screen detection
+// Manage responsive layout state: sidebar collapse, action panel collapse, narrow/mobile screen detection
 export function useResponsiveLayout(): UseResponsiveLayoutResult {
   const [isNarrowScreen, setIsNarrowScreen] = useState(() => {
     if (typeof window === "undefined") return false;
     return !window.matchMedia(NARROW_BREAKPOINT).matches;
+  });
+
+  const [isMobileScreen, setIsMobileScreen] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return !window.matchMedia(MOBILE_BREAKPOINT).matches;
   });
 
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
@@ -44,6 +56,9 @@ export function useResponsiveLayout(): UseResponsiveLayoutResult {
     return readStoredBool(STORAGE_KEY_ACTION_PANEL, false);
   });
 
+  // Mobile drawer is always closed initially; opened via hamburger button
+  const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
+
   // Track narrow screen via matchMedia
   useEffect(() => {
     const mql = window.matchMedia(NARROW_BREAKPOINT);
@@ -51,10 +66,22 @@ export function useResponsiveLayout(): UseResponsiveLayoutResult {
       const narrow = !e.matches;
       setIsNarrowScreen(narrow);
       if (narrow) {
-        // Auto-collapse both panels on narrow screens
         setSidebarCollapsed(true);
         setActionPanelCollapsed(true);
       }
+    };
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+
+  // Track mobile screen via matchMedia
+  useEffect(() => {
+    const mql = window.matchMedia(MOBILE_BREAKPOINT);
+    const handler = (e: MediaQueryListEvent) => {
+      const mobile = !e.matches;
+      setIsMobileScreen(mobile);
+      // Close drawer when switching to desktop
+      if (!mobile) setMobileDrawerOpen(false);
     };
     mql.addEventListener("change", handler);
     return () => mql.removeEventListener("change", handler);
@@ -89,11 +116,23 @@ export function useResponsiveLayout(): UseResponsiveLayoutResult {
     });
   }, []);
 
+  const toggleMobileDrawer = useCallback(() => {
+    setMobileDrawerOpen((prev) => !prev);
+  }, []);
+
+  const closeMobileDrawer = useCallback(() => {
+    setMobileDrawerOpen(false);
+  }, []);
+
   return {
     sidebarCollapsed,
     toggleSidebar,
     actionPanelCollapsed,
     toggleActionPanel,
     isNarrowScreen,
+    isMobileScreen,
+    mobileDrawerOpen,
+    toggleMobileDrawer,
+    closeMobileDrawer,
   };
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -200,6 +200,41 @@ body {
   animation: slideInRight 0.3s ease-out;
 }
 
+/* ── Mobile / touch utilities ─────────────────────────────────────────── */
+
+/* Minimum 44×44 px tap target (WCAG 2.5.5) */
+.touch-target {
+  min-width: 44px;
+  min-height: 44px;
+}
+
+/* Smaller variant — 36 px — for dense toolbars that still need decent touch area */
+.touch-target-sm {
+  min-height: 36px;
+}
+
+/* iOS safe-area insets so content is not hidden under the notch/home indicator */
+.safe-top {
+  padding-top: env(safe-area-inset-top, 0px);
+}
+
+.safe-bottom {
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+/* Prevent rubber-band scroll on the root shell; individual panels use overflow-y-auto */
+html, body {
+  overscroll-behavior: none;
+}
+
+/* Prevent text size adjustment on orientation change (iOS Safari) */
+html {
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
+/* ── End mobile utilities ──────────────────────────────────────────────── */
+
 /* Thin overlay scrollbar — applied globally to all scrollable areas */
 *::-webkit-scrollbar {
   width: 6px;


### PR DESCRIPTION
## Summary

Resolves #5. Makes the existing WebUI fully usable on mobile viewports (< 768px) without any separate mobile code path.

- **Off-canvas drawer navigation**: hamburger button in mobile top bar opens a slide-in sidebar drawer with full agent/project/terminal list; tapping backdrop or selecting an item closes it
- **Mobile top bar**: `StatusBar` gains an `isMobile` mode with hamburger + logo + settings icons at 44 px touch targets
- **Touch-friendly controls**: all interactive buttons across `TerminalPanel`, `PreviewPanel`, `AgentActions`, `WorktreePanel`, `BranchGraph` get `touch-target-sm` (36 px min-height) or `touch-target` (44 px)
- **Terminal touch support**: `onTouchStart` in `TerminalPanel` enters select mode so text is scrollable/copyable on touch devices
- **MarkdownPanel file tree**: on mobile the tree collapses into an overlay drawer toggled by a grid-icon button in the header; auto-closes after selecting a file
- **Responsive headers**: `WorktreePanel` and `BranchGraph` headers use `flex-wrap` so controls reflow instead of overflowing on small screens; stats row hidden on smallest breakpoints
- **Split view disabled on mobile**: `showSplitView` guards against `isMobileScreen` so the draggable pane is never activated on touch
- **CSS utilities**: `.touch-target`, `.touch-target-sm`, `.safe-top`, `.safe-bottom` (iOS safe-area-inset), `overscroll-behavior: none`, `-webkit-text-size-adjust: 100%`

## Breakpoints

| Width | Behaviour |
|-------|-----------|
| ≥ 1024px | Full 3-column layout (sidebar + main + action panel) |
| 768–1023px | Narrow mode: sidebar/action panel collapsed |
| < 768px | Mobile mode: off-canvas drawer, single-pane, touch-optimised |

## Test plan

- [x] `pnpm test` — 174 tests pass
- [x] `pnpm lint` — biome clean
- [x] `pnpm build` — build succeeds
- [ ] Open at 375 px (iPhone SE): hamburger opens/closes drawer, agent selection collapses drawer, PreviewPanel footer buttons are fingertip-reachable
- [ ] Open at 768 px (tablet): sidebar collapse/expand works, split view absent
- [ ] Open at 1024 px+ (desktop): behaviour unchanged from before this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * モバイルデバイス向けナビゲーションドロアーと上部ステータスバーを追加

* **スタイル・UI改善**
  * タッチ操作に対応した大きなボタンサイズを実装
  * レスポンシブレイアウトを最適化
  * モバイル画面でのテキスト自動スケーリングを改善
  * iOSのセーフエリア対応を追加
  * モバイル上でのスクロール動作を改善

<!-- end of auto-generated comment: release notes by coderabbit.ai -->